### PR TITLE
Improve TX filtering API

### DIFF
--- a/src/fnmp.props
+++ b/src/fnmp.props
@@ -3,7 +3,7 @@
     <!-- Defines the project version numbers -->
     <MajorVersion>0</MajorVersion>
     <MinorVersion>2</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
   </PropertyGroup>
   <!-- The set of (eventually?) supported configurations -->
   <ItemGroup Label="ProjectConfigurations">

--- a/src/sys/fnio/filter.c
+++ b/src/sys/fnio/filter.c
@@ -105,7 +105,7 @@ FnIoFilterNbl(
     ASSERT(Buffer != NULL);
 
     for (UINT32 Index = 0; Index < DataLength; Index++) {
-        if ((Buffer[Index] & Filter->Params.Mask[Index]) != Filter->Params.Pattern[Index]) {
+        if (((Buffer[Index] ^ Filter->Params.Pattern[Index]) & Filter->Params.Mask[Index])) {
             return FALSE;
         }
     }


### PR DESCRIPTION
Only check whether the masked packet bits match the masked pattern bits in the TX filtering routine.