### PR TITLE
Restore Nuget Packages in OneBranch Builds

### DIFF
--- a/.azure/OneBranch.Official.yml
+++ b/.azure/OneBranch.Official.yml
@@ -89,6 +89,7 @@ extends:
         parameters:
           sln: fnmp.sln
           platform: 'x64,arm64'
+          restoreNugetPackages: true
           outputDirectory: 'artifacts'
           # Package args
           package: ${{ parameters.package }}

--- a/.azure/OneBranch.PullRequest.yml
+++ b/.azure/OneBranch.PullRequest.yml
@@ -50,4 +50,5 @@ extends:
         parameters:
           sln: fnmp.sln
           platform: 'x64,arm64'
+          restoreNugetPackages: true
           outDir: 'artifacts'


### PR DESCRIPTION
Internal build was failing because of missing nuget package dependencies.