### PR TITLE
Fix OneBranch Builds

### DIFF
--- a/.azure/OneBranch.Official.yml
+++ b/.azure/OneBranch.Official.yml
@@ -89,6 +89,7 @@ extends:
         parameters:
           sln: fnmp.sln
           platform: 'x64,arm64'
+          restoreNugetPackages: true
           outputDirectory: 'artifacts'
           # Package args
           package: ${{ parameters.package }}

--- a/.azure/OneBranch.PullRequest.yml
+++ b/.azure/OneBranch.PullRequest.yml
@@ -50,4 +50,5 @@ extends:
         parameters:
           sln: fnmp.sln
           platform: 'x64,arm64'
+          restoreNugetPackages: true
           outDir: 'artifacts'

--- a/test/functional/fnmpfunctionaltests.vcxproj
+++ b/test/functional/fnmpfunctionaltests.vcxproj
@@ -3,7 +3,9 @@
   <PropertyGroup>
     <ProjectGuid>{02D631DF-E2E7-4A6E-9773-94A45B19C367}</ProjectGuid>
     <TargetName>fnmpfunctionaltests</TargetName>
-    <UndockedType>dll</UndockedType>
+    <!-- Temporary hack to disable linking stage in official OneBranch builds, because it's broken -->
+    <UndockedType Condition="'$(UndockedOfficial)' != 'true'">dll</UndockedType>
+    <UndockedType Condition="'$(UndockedOfficial)' == 'true'">lib</UndockedType>
     <UndockedDir>$(SolutionDir)submodules\undocked\</UndockedDir>
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>


### PR DESCRIPTION
Fixes two problems:

1. Link error from `fnmpfunctionaltests` - by changing it to a static lib (hack) to not link anything
2. arm64x build error for drvlib - Disable this (in the undocked repo) and update the submodule dependency