### PR TITLE
Fix functional tests - script error and local debug execution

### DIFF
--- a/fnmp.sln
+++ b/fnmp.sln
@@ -17,6 +17,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bounce", "src\sys\bounce\bo
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fnio", "src\sys\fnio\fnio.vcxproj", "{D07EDEB2-006F-4B32-8CD1-2B8FABD5879E}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "debugcrt", "test\debugcrt\debugcrt.vcxproj", "{74f5716d-c62f-45d4-9cc2-4637440d5e4e}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -97,6 +99,18 @@ Global
 		{D07EDEB2-006F-4B32-8CD1-2B8FABD5879E}.Release|x64.ActiveCfg = Release|x64
 		{D07EDEB2-006F-4B32-8CD1-2B8FABD5879E}.Release|x64.Build.0 = Release|x64
 		{D07EDEB2-006F-4B32-8CD1-2B8FABD5879E}.Release|x64.Deploy.0 = Release|x64
+		{74f5716d-c62f-45d4-9cc2-4637440d5e4e}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{74f5716d-c62f-45d4-9cc2-4637440d5e4e}.Debug|ARM64.Build.0 = Debug|ARM64
+		{74f5716d-c62f-45d4-9cc2-4637440d5e4e}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{74f5716d-c62f-45d4-9cc2-4637440d5e4e}.Debug|x64.ActiveCfg = Debug|x64
+		{74f5716d-c62f-45d4-9cc2-4637440d5e4e}.Debug|x64.Build.0 = Debug|x64
+		{74f5716d-c62f-45d4-9cc2-4637440d5e4e}.Debug|x64.Deploy.0 = Debug|x64
+		{74f5716d-c62f-45d4-9cc2-4637440d5e4e}.Release|ARM64.ActiveCfg = Release|ARM64
+		{74f5716d-c62f-45d4-9cc2-4637440d5e4e}.Release|ARM64.Build.0 = Release|ARM64
+		{74f5716d-c62f-45d4-9cc2-4637440d5e4e}.Release|ARM64.Deploy.0 = Release|ARM64
+		{74f5716d-c62f-45d4-9cc2-4637440d5e4e}.Release|x64.ActiveCfg = Release|x64
+		{74f5716d-c62f-45d4-9cc2-4637440d5e4e}.Release|x64.Build.0 = Release|x64
+		{74f5716d-c62f-45d4-9cc2-4637440d5e4e}.Release|x64.Deploy.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/test/debugcrt/debugcrt.vcxproj
+++ b/test/debugcrt/debugcrt.vcxproj
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{74f5716d-c62f-45d4-9cc2-4637440d5e4e}</ProjectGuid>
+    <RootNamespace>debugcrt</RootNamespace>
+    <UndockedType>dll</UndockedType>
+  </PropertyGroup>
+  <Import Project="$(SolutionDir)submodules\undocked\vs\windows.undocked.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Utility</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <ImportGroup Label="ExtensionSettings" />
+  <!-- Redistribute the debug CRT to test machines. -->
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <VCRedistVersion Condition="exists('$(VCInstallDir)Auxiliary\Build\Microsoft.VCRedistVersion.default.txt')">$([System.IO.File]::ReadAllText($(VCInstallDir)Auxiliary\Build\Microsoft.VCRedistVersion.default.txt).Trim())</VCRedistVersion>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <PostBuildEvent>
+      <Command>xcopy "$(VCInstallDir)redist\MSVC\$(VCRedistVersion)\onecore\debug_nonredist\$(PlatformShortName)\Microsoft.VC$(PlatformToolsetVersion).DebugCRT\*.dll" "$(OutDir)" /D /Y &amp;&amp; xcopy "$(UniversalDebugCRT_ExecutablePath_x64)\*.dll" "$(OutDir)" /D /Y </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/test/debugcrt/debugcrt.vcxproj
+++ b/test/debugcrt/debugcrt.vcxproj
@@ -11,6 +11,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Utility</ConfigurationType>
     <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
   </PropertyGroup>
   <ImportGroup Label="ExtensionSettings" />
   <!-- Redistribute the debug CRT to test machines. -->

--- a/test/functional/fnmpfunctionaltests.vcxproj
+++ b/test/functional/fnmpfunctionaltests.vcxproj
@@ -18,6 +18,10 @@
     <ProjectReference Include="$(SolutionDir)src\lib\fnmpapi.vcxproj">
       <Project>{15de7d30-6a0b-47c7-8ddc-1cfc658e8a1e}</Project>
     </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)test\debugcrt\debugcrt.vcxproj">
+      <Project>{74f5716d-c62f-45d4-9cc2-4637440d5e4e}</Project>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="tests.cpp" />

--- a/tools/functional.ps1
+++ b/tools/functional.ps1
@@ -55,11 +55,10 @@ param (
 Set-StrictMode -Version 'Latest'
 $ErrorActionPreference = 'Stop'
 
-. $RootDir\tools\common.ps1
-Generate-WinConfig $Arch $Config
-
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
+. $RootDir\tools\common.ps1
+Generate-WinConfig $Arch $Config
 $ArtifactsDir = "$RootDir\artifacts\bin\$($WinArch)$($WinConfig)"
 $LogsDir = "$RootDir\artifacts\logs"
 $IterationFailureCount = 0


### PR DESCRIPTION
- Fix script error.
- Copy debug CRT binaries to output directory on debug builds, so test machines without VS installed can load their CRT.

Resolves #26 