### PR TITLE
Binplace FNMPAPI.dll into system32

### DIFF
--- a/src/lib/fnmpapi.vcxproj
+++ b/src/lib/fnmpapi.vcxproj
@@ -6,6 +6,7 @@
     <UndockedType>dll</UndockedType>
     <UndockedDir>$(SolutionDir)submodules\undocked\</UndockedDir>
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
+    <UndockedUseDriverToolset>true</UndockedUseDriverToolset>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
   <Import Project="$(UndockedDir)vs\windows.undocked.props" />
@@ -13,6 +14,7 @@
   <ItemGroup>
     <ClCompile Include="ioctl.c" />
     <ClCompile Include="fnmpapi.c" />
+    <FilesToPackage Include="$(TargetPath)" />
   </ItemGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/src/sys/inf/fnmp.inx
+++ b/src/sys/inf/fnmp.inx
@@ -19,6 +19,7 @@
  BusType         = 15
  Characteristics = 0x4; NCF_PHYSICAL
  CopyFiles       = fnmp.CopyFiles
+ CopyFiles       = fnmp.CopyDllFiles
 *IfType         = 6             ; IF_TYPE_ETHERNET_CSMACD
 *MediaType      = 0             ; NdisMedium802_3
 *PhysicalMediaType = 0          ; NdisPhysicalMediumUnspecified
@@ -279,9 +280,13 @@
 
 [SourceDisksFiles]
  fnmp.Sys = 1,,
+ fnmpapi.dll = 1,,
 
 [fnmp.CopyFiles]
  fnmp.sys,,,2
+
+[fnmp.CopyDllFiles]
+ fnmpapi.dll,,,2
 
 [fnmp.ndi.NT.Services]
  AddService = fnmp, 2, fnmp.Service, fnmp.AddEventLog
@@ -307,6 +312,7 @@
 [DestinationDirs]
  DefaultDestDir   = 13 ; Driver Store directory
  fnmp.CopyFiles  = 13
+ fnmp.CopyDllFiles = 11
 
 
 [Strings]

--- a/src/sys/nt/fnmp.vcxproj
+++ b/src/sys/nt/fnmp.vcxproj
@@ -11,6 +11,9 @@
   <Import Project="$(UndockedDir)vs\windows.undocked.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <ItemGroup>
+    <ProjectReference Include="$(SolutionDir)src\lib\fnmpapi.vcxproj">
+      <Project>{15de7d30-6a0b-47c7-8ddc-1cfc658e8a1e}</Project>
+    </ProjectReference>
     <ProjectReference Include="$(SolutionDir)src\sys\bounce\bounce.vcxproj">
       <Project>{4a8c9c36-9b11-4bcf-9c48-0f33d4470d66}</Project>
     </ProjectReference>

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major": 0, "minor": 3, "patch": 3 }
+{ "major": 0, "minor": 3, "patch": 4 }


### PR DESCRIPTION
Consumers of FNMP don't know where to load fnmpapi.dll, so toss it into system32.