### PR TITLE
Add runtime dynamic linking API helpers

### DIFF
--- a/inc/fnlwfapi.h
+++ b/inc/fnlwfapi.h
@@ -9,7 +9,10 @@ EXTERN_C_START
 
 #include <fniotypes.h>
 
-#ifndef FNLWFAPI
+#if defined(FNLWFAPI_DYNAMIC_LOAD)
+#include <fnlwfapi_dyn.h>
+#define FNLWFAPI inline
+#elif !defined(FNLWFAPI)
 #define FNLWFAPI __declspec(dllimport)
 #endif
 

--- a/inc/fnlwfapi_dyn.h
+++ b/inc/fnlwfapi_dyn.h
@@ -98,7 +98,7 @@ typedef struct _FNLWF_LOAD_CONTEXT *FNLWF_LOAD_API_CONTEXT;
 
 extern FNLWF_LOAD_API_CONTEXT FnLwfLoadApiContext;
 
-#define LOAD_FN(TYPE, Name) \
+#define FNLWF_LOAD_FN(TYPE, Name) \
     static TYPE *Fn; \
     if (Fn == NULL) { \
         Fn = (TYPE *)GetProcAddress((HMODULE)FnLwfLoadApiContext, Name); \
@@ -114,7 +114,7 @@ FnLwfOpenDefault(
     _Out_ HANDLE *Handle
     )
 {
-    LOAD_FN(FNLWF_OPEN_DEFAULT, __FUNCTION__);
+    FNLWF_LOAD_FN(FNLWF_OPEN_DEFAULT, __FUNCTION__);
     return Fn(IfIndex, Handle);
 }
 
@@ -125,7 +125,7 @@ FnLwfTxEnqueue(
     _In_ DATA_FRAME *Frame
     )
 {
-    LOAD_FN(FNLWF_TX_ENQUEUE, __FUNCTION__);
+    FNLWF_LOAD_FN(FNLWF_TX_ENQUEUE, __FUNCTION__);
     return Fn(Handle, Frame);
 }
 
@@ -136,7 +136,7 @@ FnLwfTxFlush(
     _In_opt_ DATA_FLUSH_OPTIONS *Options
     )
 {
-    LOAD_FN(FNLWF_TX_FLUSH, __FUNCTION__);
+    FNLWF_LOAD_FN(FNLWF_TX_FLUSH, __FUNCTION__);
      return Fn(Handle, Options);
 }
 
@@ -149,7 +149,7 @@ FnLwfRxFilter(
     _In_ UINT32 Length
     )
 {
-    LOAD_FN(FNLWF_RX_FILTER, __FUNCTION__);
+    FNLWF_LOAD_FN(FNLWF_RX_FILTER, __FUNCTION__);
     return Fn(Handle, Pattern, Mask, Length);
 }
 
@@ -162,7 +162,7 @@ FnLwfRxGetFrame(
     _Out_opt_ DATA_FRAME *Frame
     )
 {
-    LOAD_FN(FNLWF_RX_GET_FRAME, __FUNCTION__);
+    FNLWF_LOAD_FN(FNLWF_RX_GET_FRAME, __FUNCTION__);
     return Fn(Handle, FrameIndex, FrameBufferLength, Frame);
 }
 
@@ -173,7 +173,7 @@ FnLwfRxDequeueFrame(
     _In_ UINT32 FrameIndex
     )
 {
-    LOAD_FN(FNLWF_RX_DEQUEUE_FRAME, __FUNCTION__);
+    FNLWF_LOAD_FN(FNLWF_RX_DEQUEUE_FRAME, __FUNCTION__);
     return Fn(Handle, FrameIndex);
 }
 
@@ -183,7 +183,7 @@ FnLwfRxFlush(
     _In_ HANDLE Handle
     )
 {
-    LOAD_FN(FNLWF_RX_FLUSH, __FUNCTION__);
+    FNLWF_LOAD_FN(FNLWF_RX_FLUSH, __FUNCTION__);
     return Fn(Handle);
 }
 
@@ -196,7 +196,7 @@ FnLwfOidSubmitRequest(
     _Inout_opt_ VOID *InformationBuffer
     )
 {
-    LOAD_FN(FNLWF_OID_SUBMIT_REQUEST, __FUNCTION__);
+    FNLWF_LOAD_FN(FNLWF_OID_SUBMIT_REQUEST, __FUNCTION__);
     return Fn(Handle, Key, InformationBufferLength, InformationBuffer);
 }
 
@@ -209,7 +209,7 @@ FnLwfStatusSetFilter(
     _In_ BOOLEAN QueueIndications
     )
 {
-    LOAD_FN(FNLWF_STATUS_SET_FILTER, __FUNCTION__);
+    FNLWF_LOAD_FN(FNLWF_STATUS_SET_FILTER, __FUNCTION__);
     return Fn(Handle, StatusCode, BlockIndications, QueueIndications);
 }
 
@@ -221,7 +221,7 @@ FnLwfStatusGetIndication(
     _Out_writes_bytes_opt_(*StatusBufferLength) VOID *StatusBuffer
     )
 {
-    LOAD_FN(FNLWF_STATUS_GET_INDICATION, __FUNCTION__);
+    FNLWF_LOAD_FN(FNLWF_STATUS_GET_INDICATION, __FUNCTION__);
     return Fn(Handle, StatusBufferLength, StatusBuffer);
 }
 
@@ -232,7 +232,7 @@ FnLwfDatapathGetState(
     BOOLEAN *IsDatapathActive
     )
 {
-    LOAD_FN(FNLWF_DATAPATH_GET_STATE, __FUNCTION__);
+    FNLWF_LOAD_FN(FNLWF_DATAPATH_GET_STATE, __FUNCTION__);
     return Fn(Handle, IsDatapathActive);
 }
 

--- a/inc/fnlwfapi_dyn.h
+++ b/inc/fnlwfapi_dyn.h
@@ -1,0 +1,270 @@
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+
+#pragma once
+
+EXTERN_C_START
+
+#include <fniotypes.h>
+
+typedef
+HRESULT
+FNLWF_OPEN_DEFAULT(
+    _In_ UINT32 IfIndex,
+    _Out_ HANDLE *Handle
+    );
+
+typedef
+HRESULT
+FNLWF_TX_ENQUEUE(
+    _In_ HANDLE Handle,
+    _In_ DATA_FRAME *Frame
+    );
+
+typedef
+HRESULT
+FNLWF_TX_FLUSH(
+    _In_ HANDLE Handle,
+    _In_opt_ DATA_FLUSH_OPTIONS *Options
+    );
+
+typedef
+HRESULT
+FNLWF_RX_FILTER(
+    _In_ HANDLE Handle,
+    _In_ const VOID *Pattern,
+    _In_ const VOID *Mask,
+    _In_ UINT32 Length
+    );
+
+typedef
+HRESULT
+FNLWF_RX_GET_FRAME(
+    _In_ HANDLE Handle,
+    _In_ UINT32 FrameIndex,
+    _Inout_ UINT32 *FrameBufferLength,
+    _Out_opt_ DATA_FRAME *Frame
+    );
+
+typedef
+HRESULT
+FNLWF_RX_DEQUEUE_FRAME(
+    _In_ HANDLE Handle,
+    _In_ UINT32 FrameIndex
+    );
+
+typedef
+HRESULT
+FNLWF_RX_FLUSH(
+    _In_ HANDLE Handle
+    );
+
+typedef
+HRESULT
+FNLWF_OID_SUBMIT_REQUEST(
+    _In_ HANDLE Handle,
+    _In_ OID_KEY Key,
+    _Inout_ UINT32 *InformationBufferLength,
+    _Inout_opt_ VOID *InformationBuffer
+    );
+
+typedef
+HRESULT
+FNLWF_STATUS_SET_FILTER(
+    _In_ HANDLE Handle,
+    _In_ NDIS_STATUS StatusCode,
+    _In_ BOOLEAN BlockIndications,
+    _In_ BOOLEAN QueueIndications
+    );
+
+typedef
+HRESULT
+FNLWF_STATUS_GET_INDICATION(
+    _In_ HANDLE Handle,
+    _Inout_ UINT32 *StatusBufferLength,
+    _Out_writes_bytes_opt_(*StatusBufferLength) VOID *StatusBuffer
+    );
+
+typedef
+HRESULT
+FNLWF_DATAPATH_GET_STATE(
+    _In_ HANDLE Handle,
+    BOOLEAN *IsDatapathActive
+    );
+
+typedef struct _FNLWF_LOAD_CONTEXT *FNLWF_LOAD_API_CONTEXT;
+
+extern FNLWF_LOAD_API_CONTEXT *FnLwfLoadApiContext;
+
+#define LOAD_FN(TYPE, Name) \
+    static TYPE *Fn; \
+    if (Fn == NULL) { \
+        Fn = (TYPE *)GetProcAddress((HMODULE)FnLwfLoadApiContext, Name); \
+    } \
+    if (Fn == NULL) { \
+        return E_NOINTERFACE; \
+    }
+
+inline
+HRESULT
+FnLwfOpenDefault(
+    _In_ UINT32 IfIndex,
+    _Out_ HANDLE *Handle
+    )
+{
+    LOAD_FN(FNLWF_OPEN_DEFAULT, __FUNCTION__);
+    return Fn(IfIndex, Handle);
+}
+
+inline
+HRESULT
+FnLwfTxEnqueue(
+    _In_ HANDLE Handle,
+    _In_ DATA_FRAME *Frame
+    )
+{
+    LOAD_FN(FNLWF_TX_ENQUEUE, __FUNCTION__);
+    return Fn(Handle, Frame);
+}
+
+inline
+HRESULT
+FnLwfTxFlush(
+    _In_ HANDLE Handle,
+    _In_opt_ DATA_FLUSH_OPTIONS *Options
+    )
+{
+    LOAD_FN(FNLWF_TX_FLUSH, __FUNCTION__);
+     return Fn(Handle, Options);
+}
+
+inline
+HRESULT
+FnLwfRxFilter(
+    _In_ HANDLE Handle,
+    _In_ const VOID *Pattern,
+    _In_ const VOID *Mask,
+    _In_ UINT32 Length
+    )
+{
+    LOAD_FN(FNLWF_RX_FILTER, __FUNCTION__);
+    return Fn(Handle, Pattern, Mask, Length);
+}
+
+inline
+HRESULT
+FnLwfRxGetFrame(
+    _In_ HANDLE Handle,
+    _In_ UINT32 FrameIndex,
+    _Inout_ UINT32 *FrameBufferLength,
+    _Out_opt_ DATA_FRAME *Frame
+    )
+{
+    LOAD_FN(FNLWF_RX_GET_FRAME, __FUNCTION__);
+    return Fn(Handle, FrameIndex, FrameBufferLength, Frame);
+}
+
+inline
+HRESULT
+FnLwfRxDequeueFrame(
+    _In_ HANDLE Handle,
+    _In_ UINT32 FrameIndex
+    )
+{
+    LOAD_FN(FNLWF_RX_DEQUEUE_FRAME, __FUNCTION__);
+    return Fn(Handle, FrameIndex);
+}
+
+inline
+HRESULT
+FnLwfRxFlush(
+    _In_ HANDLE Handle
+    )
+{
+    LOAD_FN(FNLWF_RX_FLUSH, __FUNCTION__);
+    return Fn(Handle);
+}
+
+inline
+HRESULT
+FnLwfOidSubmitRequest(
+    _In_ HANDLE Handle,
+    _In_ OID_KEY Key,
+    _Inout_ UINT32 *InformationBufferLength,
+    _Inout_opt_ VOID *InformationBuffer
+    )
+{
+    LOAD_FN(FNLWF_OID_SUBMIT_REQUEST, __FUNCTION__);
+    return Fn(Handle, Key, InformationBufferLength, InformationBuffer);
+}
+
+inline
+HRESULT
+FnLwfStatusSetFilter(
+    _In_ HANDLE Handle,
+    _In_ NDIS_STATUS StatusCode,
+    _In_ BOOLEAN BlockIndications,
+    _In_ BOOLEAN QueueIndications
+    )
+{
+    LOAD_FN(FNLWF_STATUS_SET_FILTER, __FUNCTION__);
+    return Fn(Handle, StatusCode, BlockIndications, QueueIndications);
+}
+
+inline
+HRESULT
+FnLwfStatusGetIndication(
+    _In_ HANDLE Handle,
+    _Inout_ UINT32 *StatusBufferLength,
+    _Out_writes_bytes_opt_(*StatusBufferLength) VOID *StatusBuffer
+    )
+{
+    LOAD_FN(FNLWF_STATUS_GET_INDICATION, __FUNCTION__);
+    return Fn(Handle, StatusBufferLength, StatusBuffer);
+}
+
+inline
+HRESULT
+FnLwfDatapathGetState(
+    _In_ HANDLE Handle,
+    BOOLEAN *IsDatapathActive
+    )
+{
+    LOAD_FN(FNLWF_DATAPATH_GET_STATE, __FUNCTION__);
+    return Fn(Handle, IsDatapathActive);
+}
+
+inline
+HRESULT
+FnLwfLoadApi(
+    )
+{
+    HRESULT Result;
+    HMODULE ModuleHandle;
+
+    *FnLwfLoadApiContext = NULL;
+
+    ModuleHandle = LoadLibraryA("fnlwfapi.dll");
+    if (ModuleHandle == NULL) {
+        Result = E_NOINTERFACE;
+    } else {
+        *FnLwfLoadApiContext = (FNLWF_LOAD_API_CONTEXT)ModuleHandle;
+        Result = S_OK;
+    }
+
+    return Result;
+}
+
+inline
+VOID
+FnLwfUnloadApi(
+    )
+{
+    HMODULE ModuleHandle = (HMODULE)FnLwfLoadApiContext;
+
+    FreeLibrary(ModuleHandle);
+}
+
+EXTERN_C_END

--- a/inc/fnlwfapi_dyn.h
+++ b/inc/fnlwfapi_dyn.h
@@ -96,7 +96,7 @@ FNLWF_DATAPATH_GET_STATE(
 
 typedef struct _FNLWF_LOAD_CONTEXT *FNLWF_LOAD_API_CONTEXT;
 
-extern FNLWF_LOAD_API_CONTEXT *FnLwfLoadApiContext;
+extern FNLWF_LOAD_API_CONTEXT FnLwfLoadApiContext;
 
 #define LOAD_FN(TYPE, Name) \
     static TYPE *Fn; \
@@ -244,13 +244,11 @@ FnLwfLoadApi(
     HRESULT Result;
     HMODULE ModuleHandle;
 
-    *FnLwfLoadApiContext = NULL;
-
     ModuleHandle = LoadLibraryA("fnlwfapi.dll");
     if (ModuleHandle == NULL) {
         Result = E_NOINTERFACE;
     } else {
-        *FnLwfLoadApiContext = (FNLWF_LOAD_API_CONTEXT)ModuleHandle;
+        FnLwfLoadApiContext = (FNLWF_LOAD_API_CONTEXT)ModuleHandle;
         Result = S_OK;
     }
 

--- a/inc/fnmpapi.h
+++ b/inc/fnmpapi.h
@@ -9,7 +9,10 @@ EXTERN_C_START
 
 #include <fniotypes.h>
 
-#ifndef FNMPAPI
+#if defined(FNLWFAPI_DYNAMIC_LOAD)
+#include <fnmpapi_dyn.h>
+#define FNMPAPI inline
+#elif !defined(FNMPAPI)
 #define FNMPAPI __declspec(dllimport)
 #endif
 

--- a/inc/fnmpapi.h
+++ b/inc/fnmpapi.h
@@ -9,7 +9,7 @@ EXTERN_C_START
 
 #include <fniotypes.h>
 
-#if defined(FNLWFAPI_DYNAMIC_LOAD)
+#if defined(FNMPAPI_DYNAMIC_LOAD)
 #include <fnmpapi_dyn.h>
 #define FNMPAPI inline
 #elif !defined(FNMPAPI)

--- a/inc/fnmpapi_dyn.h
+++ b/inc/fnmpapi_dyn.h
@@ -1,0 +1,330 @@
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+
+#pragma once
+
+EXTERN_C_START
+
+#include <fniotypes.h>
+
+typedef
+HRESULT
+FNMP_OPEN_SHARED(
+    _In_ UINT32 IfIndex,
+    _Out_ HANDLE *Handle
+    );
+
+typedef
+HRESULT
+FNMP_OPEN_EXCLUSIVE(
+    _In_ UINT32 IfIndex,
+    _Out_ HANDLE *Handle
+    );
+
+typedef
+HRESULT
+FNMP_RX_ENQUEUE(
+    _In_ HANDLE Handle,
+    _In_ DATA_FRAME *Frame
+    );
+
+typedef
+HRESULT
+FNMP_RX_FLUSH(
+    _In_ HANDLE Handle,
+    _In_opt_ DATA_FLUSH_OPTIONS *Options
+    );
+
+typedef
+HRESULT
+FNMP_TX_FILTER(
+    _In_ HANDLE Handle,
+    _In_ const VOID *Pattern,
+    _In_ const VOID *Mask,
+    _In_ UINT32 Length
+    );
+
+typedef
+HRESULT
+FNMP_TX_GET_FRAME(
+    _In_ HANDLE Handle,
+    _In_ UINT32 FrameIndex,
+    _In_ UINT32 FrameSubIndex,
+    _Inout_ UINT32 *FrameBufferLength,
+    _Out_opt_ DATA_FRAME *Frame
+    );
+
+typedef
+HRESULT
+FNMP_TX_DEQUEUE_FRAME(
+    _In_ HANDLE Handle,
+    _In_ UINT32 FrameIndex
+    );
+
+typedef
+HRESULT
+FNMP_TX_FLUSH(
+    _In_ HANDLE Handle
+    );
+
+typedef
+HRESULT
+FNMP_GET_LAST_MINIPORT_TIMESTAMP(
+    _In_ HANDLE Handle,
+    _Out_ LARGE_INTEGER *Timestamp
+    );
+
+typedef
+HRESULT
+FNMP_SET_MTU(
+    _In_ HANDLE Handle,
+    _In_ UINT32 Mtu
+    );
+
+typedef
+HRESULT
+FNMP_OID_FILTER(
+    _In_ HANDLE Handle,
+    _In_ const OID_KEY *Keys,
+    _In_ UINT32 KeyCount
+    );
+
+typedef
+HRESULT
+FNMP_OID_GET_REQUEST(
+    _In_ HANDLE Handle,
+    _In_ OID_KEY Key,
+    _Inout_ UINT32 *InformationBufferLength,
+    _Out_opt_ VOID *InformationBuffer
+    );
+
+typedef
+HRESULT
+FNMP_OID_COMPLETE_REQUEST(
+    _In_ HANDLE Handle,
+    _In_ OID_KEY Key,
+    _In_ NDIS_STATUS Status,
+    _In_opt_ const VOID *InformationBuffer,
+    _In_ UINT32 InformationBufferLength
+    );
+
+typedef
+HRESULT
+FNMP_UPDATE_TASK_OFFLOAD(
+    _In_ HANDLE Handle,
+    _In_ FN_OFFLOAD_TYPE OffloadType,
+    _In_opt_ const NDIS_OFFLOAD_PARAMETERS *OffloadParameters,
+    _In_ UINT32 OffloadParametersLength
+    );
+
+typedef struct _FNMP_LOAD_CONTEXT *FNMP_LOAD_API_CONTEXT;
+
+extern FNMP_LOAD_API_CONTEXT FnMpLoadApiContext;
+
+#define FNMP_LOAD_FN(TYPE, Name) \
+    static TYPE *Fn; \
+    if (Fn == NULL) { \
+        Fn = (TYPE *)GetProcAddress((HMODULE)FnMpLoadApiContext, Name); \
+    } \
+    if (Fn == NULL) { \
+        return E_NOINTERFACE; \
+    }
+
+inline
+HRESULT
+FnMpOpenShared(
+    _In_ UINT32 IfIndex,
+    _Out_ HANDLE *Handle
+    )
+{
+    FNMP_LOAD_FN(FNMP_OPEN_SHARED, __FUNCTION__);
+    return Fn(IfIndex, Handle);
+}
+
+inline
+HRESULT
+FnMpOpenExclusive(
+    _In_ UINT32 IfIndex,
+    _Out_ HANDLE *Handle
+    )
+{
+    FNMP_LOAD_FN(FNMP_OPEN_EXCLUSIVE, __FUNCTION__);
+    return Fn(IfIndex, Handle);
+}
+
+inline
+HRESULT
+FnMpRxEnqueue(
+    _In_ HANDLE Handle,
+    _In_ DATA_FRAME *Frame
+    )
+{
+    FNMP_LOAD_FN(FNMP_RX_ENQUEUE, __FUNCTION__);
+    return Fn(Handle, Frame);
+}
+
+inline
+HRESULT
+FnMpRxFlush(
+    _In_ HANDLE Handle,
+    _In_opt_ DATA_FLUSH_OPTIONS *Options
+    )
+{
+    FNMP_LOAD_FN(FNMP_RX_FLUSH, __FUNCTION__);
+    return Fn(Handle, Options);
+}
+
+inline
+HRESULT
+FnMpTxFilter(
+    _In_ HANDLE Handle,
+    _In_ const VOID *Pattern,
+    _In_ const VOID *Mask,
+    _In_ UINT32 Length
+    )
+{
+    FNMP_LOAD_FN(FNMP_TX_FILTER, __FUNCTION__);
+    return Fn(Handle, Pattern, Mask, Length);
+}
+
+inline
+HRESULT
+FnMpTxGetFrame(
+    _In_ HANDLE Handle,
+    _In_ UINT32 FrameIndex,
+    _In_ UINT32 FrameSubIndex,
+    _Inout_ UINT32 *FrameBufferLength,
+    _Out_opt_ DATA_FRAME *Frame
+    )
+{
+    FNMP_LOAD_FN(FNMP_TX_GET_FRAME, __FUNCTION__);
+    return Fn(Handle, FrameIndex, FrameSubIndex, FrameBufferLength, Frame);
+}
+
+inline
+HRESULT
+FnMpTxDequeueFrame(
+    _In_ HANDLE Handle,
+    _In_ UINT32 FrameIndex
+    )
+{
+    FNMP_LOAD_FN(FNMP_TX_DEQUEUE_FRAME, __FUNCTION__);
+    return Fn(Handle, FrameIndex);
+}
+
+inline
+HRESULT
+FnMpTxFlush(
+    _In_ HANDLE Handle
+    )
+{
+    FNMP_LOAD_FN(FNMP_TX_FLUSH, __FUNCTION__);
+    return Fn(Handle);
+}
+
+inline
+HRESULT
+FnMpGetLastMiniportPauseTimestamp(
+    _In_ HANDLE Handle,
+    _Out_ LARGE_INTEGER *Timestamp
+    )
+{
+    FNMP_LOAD_FN(FNMP_GET_LAST_MINIPORT_TIMESTAMP, __FUNCTION__);
+    return Fn(Handle, Timestamp);
+}
+
+inline
+HRESULT
+FnMpSetMtu(
+    _In_ HANDLE Handle,
+    _In_ UINT32 Mtu
+    )
+{
+    FNMP_LOAD_FN(FNMP_SET_MTU, __FUNCTION__);
+    return Fn(Handle, Mtu);
+}
+
+inline
+HRESULT
+FnMpOidFilter(
+    _In_ HANDLE Handle,
+    _In_ const OID_KEY *Keys,
+    _In_ UINT32 KeyCount
+    )
+{
+    FNMP_LOAD_FN(FNMP_OID_FILTER, __FUNCTION__);
+    return Fn(Handle, Keys, KeyCount);
+}
+
+inline
+HRESULT
+FnMpOidGetRequest(
+    _In_ HANDLE Handle,
+    _In_ OID_KEY Key,
+    _Inout_ UINT32 *InformationBufferLength,
+    _Out_opt_ VOID *InformationBuffer
+    )
+{
+    FNMP_LOAD_FN(FNMP_OID_GET_REQUEST, __FUNCTION__);
+    return Fn(Handle, Key, InformationBufferLength, InformationBuffer);
+}
+
+inline
+HRESULT
+FnMpOidCompleteRequest(
+    _In_ HANDLE Handle,
+    _In_ OID_KEY Key,
+    _In_ NDIS_STATUS Status,
+    _In_opt_ const VOID *InformationBuffer,
+    _In_ UINT32 InformationBufferLength
+    )
+{
+    FNMP_LOAD_FN(FNMP_OID_COMPLETE_REQUEST, __FUNCTION__);
+    return Fn(Handle, Key, Status, InformationBuffer, InformationBufferLength);
+}
+
+inline
+HRESULT
+FnMpUpdateTaskOffload(
+    _In_ HANDLE Handle,
+    _In_ FN_OFFLOAD_TYPE OffloadType,
+    _In_opt_ const NDIS_OFFLOAD_PARAMETERS *OffloadParameters,
+    _In_ UINT32 OffloadParametersLength
+    )
+{
+    FNMP_LOAD_FN(FNMP_UPDATE_TASK_OFFLOAD, __FUNCTION__);
+    return Fn(Handle, OffloadType, OffloadParameters, OffloadParametersLength);
+}
+
+inline
+HRESULT
+FnMpLoadApi(
+    )
+{
+    HRESULT Result;
+    HMODULE ModuleHandle;
+
+    ModuleHandle = LoadLibraryA("fnmpapi.dll");
+    if (ModuleHandle == NULL) {
+        Result = E_NOINTERFACE;
+    } else {
+        FnMpLoadApiContext = (FNMP_LOAD_API_CONTEXT)ModuleHandle;
+        Result = S_OK;
+    }
+
+    return Result;
+}
+
+inline
+VOID
+FnMpUnloadApi(
+    )
+{
+    HMODULE ModuleHandle = (HMODULE)FnMpLoadApiContext;
+
+    FreeLibrary(ModuleHandle);
+}
+
+EXTERN_C_END

--- a/test/functional/fnfunctionaltests.vcxproj
+++ b/test/functional/fnfunctionaltests.vcxproj
@@ -19,9 +19,6 @@
     <ProjectReference Include="$(SolutionDir)src\mp\lib\fnmpapi.vcxproj">
       <Project>{15de7d30-6a0b-47c7-8ddc-1cfc658e8a1e}</Project>
     </ProjectReference>
-    <ProjectReference Include="$(SolutionDir)src\lwf\lib\fnlwfapi.vcxproj">
-      <Project>{e73b68e4-1ed8-462f-a084-b5f68bef765f}</Project>
-    </ProjectReference>
     <ProjectReference Include="$(SolutionDir)test\debugcrt\debugcrt.vcxproj">
       <Project>{74f5716d-c62f-45d4-9cc2-4637440d5e4e}</Project>
       <Private>false</Private>

--- a/test/functional/fnfunctionaltests.vcxproj
+++ b/test/functional/fnfunctionaltests.vcxproj
@@ -58,6 +58,7 @@
         POOL_NX_OPTIN_AUTO=1;
         POOL_ZERO_DOWN_LEVEL_SUPPORT=1;
         UM_NDIS687=1;
+        FNLWFAPI_DYNAMIC_LOAD=1;
         %(PreprocessorDefinitions)
       </PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>

--- a/test/functional/fnfunctionaltests.vcxproj
+++ b/test/functional/fnfunctionaltests.vcxproj
@@ -16,9 +16,6 @@
     <ProjectReference Include="$(SolutionDir)test\pkthlp\um\pkthlp_um.vcxproj">
       <Project>{e84ff937-7445-4b8e-ba40-dffacc09c060}</Project>
     </ProjectReference>
-    <ProjectReference Include="$(SolutionDir)src\mp\lib\fnmpapi.vcxproj">
-      <Project>{15de7d30-6a0b-47c7-8ddc-1cfc658e8a1e}</Project>
-    </ProjectReference>
     <ProjectReference Include="$(SolutionDir)test\debugcrt\debugcrt.vcxproj">
       <Project>{74f5716d-c62f-45d4-9cc2-4637440d5e4e}</Project>
       <Private>false</Private>
@@ -55,6 +52,7 @@
         POOL_NX_OPTIN_AUTO=1;
         POOL_ZERO_DOWN_LEVEL_SUPPORT=1;
         UM_NDIS687=1;
+        FNMPAPI_DYNAMIC_LOAD=1;
         FNLWFAPI_DYNAMIC_LOAD=1;
         %(PreprocessorDefinitions)
       </PreprocessorDefinitions>

--- a/test/functional/tests.cpp
+++ b/test/functional/tests.cpp
@@ -868,6 +868,7 @@ TestSetup()
     WPP_INIT_TRACING(NULL);
     TEST_EQUAL(0, WSAStartup(MAKEWORD(2,2), &WsaData));
     TEST_EQUAL(0, InvokeSystem("netsh advfirewall firewall add rule name=fnmptest dir=in action=allow protocol=any remoteip=any localip=any"));
+    TEST_HRESULT(FnLwfLoadApi());
     WaitForWfpQuarantine(FnMpIf);
     return true;
 }
@@ -875,6 +876,7 @@ TestSetup()
 bool
 TestCleanup()
 {
+    FnLwfUnloadApi();
     TEST_EQUAL(0, InvokeSystem("netsh advfirewall firewall delete rule name=fnmptest"));
     TEST_EQUAL(0, WSACleanup());
     WPP_CLEANUP();

--- a/test/functional/tests.cpp
+++ b/test/functional/tests.cpp
@@ -37,6 +37,8 @@
 #define FNMP_IPV6_ADDRESS "fc00::200:1"
 #define FNMP_NEIGHBOR_IPV6_ADDRESS "fc00::200:2"
 
+FNLWF_LOAD_API_CONTEXT *FnLwfLoadApiContext;
+
 //
 // A timeout value that allows for a little latency, e.g. async threads to
 // execute.

--- a/test/functional/tests.cpp
+++ b/test/functional/tests.cpp
@@ -37,7 +37,7 @@
 #define FNMP_IPV6_ADDRESS "fc00::200:1"
 #define FNMP_NEIGHBOR_IPV6_ADDRESS "fc00::200:2"
 
-FNLWF_LOAD_API_CONTEXT *FnLwfLoadApiContext;
+FNLWF_LOAD_API_CONTEXT FnLwfLoadApiContext;
 
 //
 // A timeout value that allows for a little latency, e.g. async threads to

--- a/test/functional/tests.cpp
+++ b/test/functional/tests.cpp
@@ -37,6 +37,7 @@
 #define FNMP_IPV6_ADDRESS "fc00::200:1"
 #define FNMP_NEIGHBOR_IPV6_ADDRESS "fc00::200:2"
 
+FNMP_LOAD_API_CONTEXT FnMpLoadApiContext;
 FNLWF_LOAD_API_CONTEXT FnLwfLoadApiContext;
 
 //
@@ -868,6 +869,7 @@ TestSetup()
     WPP_INIT_TRACING(NULL);
     TEST_EQUAL(0, WSAStartup(MAKEWORD(2,2), &WsaData));
     TEST_EQUAL(0, InvokeSystem("netsh advfirewall firewall add rule name=fnmptest dir=in action=allow protocol=any remoteip=any localip=any"));
+    TEST_HRESULT(FnMpLoadApi());
     TEST_HRESULT(FnLwfLoadApi());
     WaitForWfpQuarantine(FnMpIf);
     return true;
@@ -877,6 +879,7 @@ bool
 TestCleanup()
 {
     FnLwfUnloadApi();
+    FnMpUnloadApi();
     TEST_EQUAL(0, InvokeSystem("netsh advfirewall firewall delete rule name=fnmptest"));
     TEST_EQUAL(0, WSACleanup());
     WPP_CLEANUP();


### PR DESCRIPTION
Add header helpers to easily consume the FNMP and FNLWF APIs using runtime dynamic linking.
Addresses #34 