### PR TITLE
Fix bug caught by OB arm64 build

### DIFF
--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -315,7 +315,13 @@ public:
     UINT64
     Remaining()
     {
-        return max(0, _TimeoutInterval - Elapsed());
+        UINT64 Remaining = _TimeoutInterval - Elapsed();
+
+        if (Remaining > _TimeoutInterval) {
+            return 0;
+        } else {
+            return Remaining;
+        }
     }
 
     bool


### PR DESCRIPTION
Fix bug caught by OB arm64 build

```
test\functional\lib\tests.cpp(318,16): Error C4296: '>': expression is always false
```