### PR TITLE
Minor header cleanup

### DIFF
--- a/inc/fnioctl_km.h
+++ b/inc/fnioctl_km.h
@@ -31,7 +31,7 @@ ZwWaitForSingleObject(
     _In_opt_ PLARGE_INTEGER Timeout
     );
 
-typedef VOID* FNIOCTL_HANDLE;
+typedef HANDLE FNIOCTL_HANDLE;
 
 inline
 NTSTATUS

--- a/inc/fnioctl_um.h
+++ b/inc/fnioctl_um.h
@@ -20,8 +20,6 @@ EXTERN_C_START
 #define STATUS_UNSUCCESSFUL ((NTSTATUS)0xC0000001L)
 #endif
 
-typedef HANDLE FNIOCTL_HANDLE;
-
 //
 // This file implements common file handle and IOCTL helpers.
 //
@@ -36,6 +34,8 @@ typedef struct _FILE_FULL_EA_INFORMATION {
     USHORT EaValueLength;
     CHAR EaName[1];
 } FILE_FULL_EA_INFORMATION;
+
+typedef HANDLE FNIOCTL_HANDLE;
 
 inline
 HRESULT

--- a/inc/fniotypes.h
+++ b/inc/fniotypes.h
@@ -10,8 +10,6 @@
 // functional test miniport/lwf (fnmp/fnlwf).
 //
 
-EXTERN_C_START
-
 #ifndef KERNEL_MODE
 //
 // This header depends on the following headers included in the following order.
@@ -24,6 +22,8 @@ EXTERN_C_START
 #include <iphlpapi.h>
 #include <ndisoobtypes.h>
 #endif
+
+EXTERN_C_START
 
 typedef struct _DATA_BUFFER {
     CONST UCHAR *VirtualAddress;


### PR DESCRIPTION
Two minor cleanups to the user-facing headers to hopefully push the mirror CI pipeline through

- Align on HANDLE as the underlying type for FNIOCTL_HANDLE
- Don't wrap included headers in extern "C"