### PR TITLE
FNMP/FNLWF: atomically complete filtered NBLs when clearing filters

### DIFF
--- a/inc/fnlwfapi.h
+++ b/inc/fnlwfapi.h
@@ -146,8 +146,8 @@ FNLWFAPI
 FNLWFAPI_STATUS
 FnLwfRxFilter(
     _In_ FNLWF_HANDLE Handle,
-    _In_ const VOID *Pattern,
-    _In_ const VOID *Mask,
+    _In_opt_bytecount_(Length) const VOID *Pattern,
+    _In_opt_bytecount_(Length) const VOID *Mask,
     _In_ UINT32 Length
     )
 {
@@ -161,7 +161,7 @@ FnLwfRxFilter(
     // Captured NBLs are returned to NDIS either by closing the RX handle or by
     // dequeuing the packet and flushing the RX context.
     //
-    // Zero-length filters disable packet captures.
+    // Zero-length filters disable packet captures and release all frames.
     //
 
     In.Pattern = (const UCHAR *)Pattern;

--- a/inc/fnmpapi.h
+++ b/inc/fnmpapi.h
@@ -167,8 +167,8 @@ FNMPAPI
 FNMPAPI_STATUS
 FnMpTxFilter(
     _In_ FNMP_HANDLE Handle,
-    _In_ const VOID *Pattern,
-    _In_ const VOID *Mask,
+    _In_opt_bytecount_(Length) const VOID *Pattern,
+    _In_opt_bytecount_(Length) const VOID *Mask,
     _In_ UINT32 Length
     )
 {
@@ -183,7 +183,7 @@ FnMpTxFilter(
     // Captured NBLs are returned to NDIS either by closing the TX handle or by
     // dequeuing the packet and flushing the TX context.
     //
-    // Zero-length filters disable packet captures.
+    // Zero-length filters disable packet captures and release all frames.
     //
 
     In.Pattern = (const UCHAR *)Pattern;


### PR DESCRIPTION
Today the filter-clearing feature leaks NBLs if any NBLs happened to be remaining in the TX/RX filter. Since it is tricky, in general, for test code to ensure the NBLs are properly completed before clearing the TX/RX filter, do it atomically.