### PR TITLE
Use and expose wskclient library

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository hosts tools used to test networking on Windows.
 * [Functional Lwf (FnLwf)](./docs/fnlwf.md)
 * [Functional Sockets (FnSock)](./docs/fnsock.md)
 * [Invoke System Relay (Isr)](./docs/isr.md)
+* [WSK Client (wskclient)](./docs/wskclient.md)
 * [Development](./docs/development.md)
 
 ## Contributing

--- a/docs/wskclient.md
+++ b/docs/wskclient.md
@@ -1,0 +1,7 @@
+# WSK Client (wskclient)
+
+This library provides a convenience wrapper around the [WSK API](https://learn.microsoft.com/en-us/windows-hardware/drivers/network/introduction-to-winsock-kernel), hiding cumbersome details like NMR, IRP and MDL management. The common socket operations are provided in both synchronous and asynchronous flavors.
+
+## API
+
+Test code can leverage the API by including [wskclient.h](../inc/wskclient.h) and linking against wskclient.lib. Kernel-mode only.

--- a/inc/fnsock.h
+++ b/inc/fnsock.h
@@ -174,6 +174,7 @@ FnSockSendto(
     _In_ FNSOCK_HANDLE Socket,
     _In_reads_bytes_(BufferLength) const CHAR* Buffer,
     _In_ INT BufferLength,
+    _In_ BOOLEAN BufferIsNonPagedPool,
     _In_ INT Flags,
     _In_reads_bytes_(AddressLength) const struct sockaddr* Address,
     _In_ INT AddressLength
@@ -185,6 +186,7 @@ FnSockRecv(
     _In_ FNSOCK_HANDLE Socket,
     _Out_writes_bytes_to_(BufferLength, return) CHAR* Buffer,
     _In_ INT BufferLength,
+    _In_ BOOLEAN BufferIsNonPagedPool,
     _In_ INT Flags
     );
 

--- a/inc/wskclient.h
+++ b/inc/wskclient.h
@@ -10,6 +10,7 @@ typedef struct _WSKCONNECTEX_COMPLETION {
     WSK_BUF WskBuf;
     KEVENT Event;
     NTSTATUS Status;
+    BOOLEAN BufLocked;
 } WSKCONNECTEX_COMPLETION, *PWSKCONNECTEX_COMPLETION;
 
 typedef struct _WSKDISCONNECT_COMPLETION {
@@ -92,7 +93,8 @@ WskConnectExSync(
     int SockType,
     PSOCKADDR Addr,
     char *Buf,
-    ULONG BufLen
+    ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool
     );
 
 NTSTATUS
@@ -102,6 +104,7 @@ WskConnectExAsync(
     PSOCKADDR Addr,
     char *Buf,
     ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool,
     _Out_ PVOID* ConnectCompletion
     );
 
@@ -198,6 +201,7 @@ WskSendExSync(
     int SockType,
     char *Buf,
     ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool,
     char* Control,
     ULONG ControlLen,
     ULONG ExpectedBytesSent,
@@ -211,6 +215,7 @@ WskSendAsync(
     int SockType,
     char *Buf,
     ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool,
     ULONG Flags,
     _Out_ PVOID* SendCompletion
     );
@@ -241,6 +246,7 @@ WskReceiveExSync(
     int SockType,
     char *Buf,
     ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool,
     PCMSGHDR Control,
     PULONG ControlLen,
     ULONG ExpectedBytesReceived,
@@ -254,6 +260,7 @@ WskReceiveAsync(
     int SockType,
     char *Buf,
     ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool,
     _Out_ PVOID* ReceiveCompletion
     );
 

--- a/inc/wskclient.h
+++ b/inc/wskclient.h
@@ -1,3 +1,8 @@
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+
 #pragma once
 
 EXTERN_C_START

--- a/inc/wskclient.h
+++ b/inc/wskclient.h
@@ -1,0 +1,336 @@
+#pragma once
+
+EXTERN_C_START
+
+#define WSKCLIENT_UNKNOWN_BYTES ((ULONG)-1)
+#define WSKCLIENT_INFINITE ((ULONG)-1)
+
+typedef struct _WSKCONNECTEX_COMPLETION {
+    PIRP Irp;
+    WSK_BUF WskBuf;
+    KEVENT Event;
+    NTSTATUS Status;
+} WSKCONNECTEX_COMPLETION, *PWSKCONNECTEX_COMPLETION;
+
+typedef struct _WSKDISCONNECT_COMPLETION {
+    PIRP Irp;
+    WSK_BUF WskBuf;
+    KEVENT Event;
+    NTSTATUS Status;
+    BOOLEAN BufLocked;
+} WSKDISCONNECT_COMPLETION, *PWSKDISCONNECT_COMPLETION;
+
+typedef struct _WSKACCEPT_COMPLETION {
+    PIRP Irp;
+    KEVENT Event;
+    NTSTATUS Status;
+} WSKACCEPT_COMPLETION, *PWSKACCEPT_COMPLETION;
+
+typedef struct _WSK_IOREQUEST_COMPLETION {
+    PIRP Irp;
+    WSK_BUF WskBuf;
+    KEVENT Event;
+    NTSTATUS Status;
+    BOOLEAN BufLocked;
+} WSKIOREQUEST_COMPLETION, *PWSKIOREQUEST_COMPLETION;
+
+NTSTATUS
+WskClientReg(
+    VOID
+    );
+
+VOID
+WskClientDereg(
+    VOID
+    );
+
+NTSTATUS
+WskSocketSync(
+    int WskSockType, // e.g. WSK_FLAG_STREAM_SOCKET
+    ADDRESS_FAMILY Family,
+    USHORT SockType, // e.g. SOCK_STREAM
+    IPPROTO Protocol,
+    _Out_ PWSK_SOCKET* Sock,
+    _In_opt_ PVOID Context,
+    _In_opt_ PVOID Dispatch
+    );
+
+NTSTATUS
+WskSocketConnectSync(
+    USHORT SockType, // e.g. SOCK_STREAM
+    IPPROTO Protocol,
+    PSOCKADDR LocalAddr,
+    PSOCKADDR RemoteAddr,
+    _Out_ PWSK_SOCKET* Sock,
+    _In_opt_ PVOID Context,
+    _In_opt_ WSK_CLIENT_CONNECTION_DISPATCH* Dispatch
+    );
+
+NTSTATUS
+WskBindSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    PSOCKADDR Addr
+    );
+
+NTSTATUS
+WskListenSync(
+    PWSK_SOCKET Sock,
+    int SockType
+    );
+
+NTSTATUS
+WskConnectSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    PSOCKADDR Addr
+    );
+
+NTSTATUS
+WskConnectExSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    PSOCKADDR Addr,
+    char *Buf,
+    ULONG BufLen
+    );
+
+NTSTATUS
+WskConnectExAsync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    PSOCKADDR Addr,
+    char *Buf,
+    ULONG BufLen,
+    _Out_ PVOID* ConnectCompletion
+    );
+
+NTSTATUS
+WskConnectExAwait(
+    _Inout_ PVOID ConnectCompletion,
+    _In_ ULONG TimeoutMs
+    );
+
+VOID
+WskConnectExCancel(
+    _Inout_ PVOID ConnectCompletion
+    );
+
+NTSTATUS
+WskAcceptSync(
+    PWSK_SOCKET ListenSock,
+    int SockType,
+    ULONG TimeoutMs,
+    _Out_ PWSK_SOCKET* AcceptSock
+    );
+
+NTSTATUS
+WskAcceptAsync(
+    PWSK_SOCKET ListenSock,
+    int SockType,
+    _Out_ PVOID* AcceptCompletion
+    );
+
+NTSTATUS
+WskAcceptAwait(
+    PVOID AcceptCompletion,
+    ULONG TimeoutMs,
+    _Out_ PWSK_SOCKET* AcceptSock
+    );
+
+VOID
+WskAcceptCancel(
+    _Inout_ PVOID AcceptCompletion
+    );
+
+NTSTATUS
+WskCloseSocketSync(
+    PWSK_SOCKET Sock
+    );
+
+NTSTATUS
+WskDisconnectSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    char *Buf,
+    ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool
+    );
+
+NTSTATUS
+WskDisconnectAsync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    char *Buf,
+    ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool,
+    ULONG Flags,
+    _Out_ PWSKDISCONNECT_COMPLETION* DisconnectCompletion
+    );
+
+NTSTATUS
+WskDisconnectAwait(
+    _Inout_ PWSKDISCONNECT_COMPLETION Completion,
+    _In_ ULONG TimeoutMs
+    );
+
+NTSTATUS
+WskAbortSync(
+    PWSK_SOCKET Sock,
+    int SockType
+    );
+
+NTSTATUS
+WskSendSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    char *Buf,
+    ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool,
+    ULONG ExpectedBytesSent,
+    ULONG Flags,
+    _Out_opt_ ULONG *BytesSent
+    );
+
+NTSTATUS
+WskSendExSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    char *Buf,
+    ULONG BufLen,
+    char* Control,
+    ULONG ControlLen,
+    ULONG ExpectedBytesSent,
+    ULONG Flags,
+    _Out_opt_ ULONG *BytesSent
+    );
+
+NTSTATUS
+WskSendAsync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    char *Buf,
+    ULONG BufLen,
+    ULONG Flags,
+    _Out_ PVOID* SendCompletion
+    );
+
+NTSTATUS
+WskSendAwait(
+    _Inout_ PVOID SendCompletion,
+    _In_ ULONG TimeoutMs,
+    _In_ ULONG ExpectedBytesSent,
+    _Out_opt_ ULONG *BytesSent
+    );
+
+NTSTATUS
+WskReceiveSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    char *Buf,
+    ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool,
+    ULONG ExpectedBytesReceived,
+    ULONG TimeoutMs,
+    _Out_opt_ ULONG *BytesReceived
+    );
+
+NTSTATUS
+WskReceiveExSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    char *Buf,
+    ULONG BufLen,
+    PCMSGHDR Control,
+    PULONG ControlLen,
+    ULONG ExpectedBytesReceived,
+    ULONG TimeoutMs,
+    _Out_opt_ ULONG *BytesReceived
+    );
+
+NTSTATUS
+WskReceiveAsync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    char *Buf,
+    ULONG BufLen,
+    _Out_ PVOID* ReceiveCompletion
+    );
+
+NTSTATUS
+WskReceiveAwait(
+    _Inout_ PVOID ReceiveCompletion,
+    _In_ ULONG TimeoutMs,
+    _In_ ULONG ExpectedBytesReceived,
+    _Out_opt_ ULONG *BytesReceived
+    );
+
+NTSTATUS
+WskSendToSync(
+    PWSK_SOCKET Sock,
+    char *Buf,
+    ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool,
+    ULONG ExpectedBytesSent,
+    _In_ PSOCKADDR RemoteAddr,
+    ULONG ControlLen,
+    _In_opt_ PCMSGHDR Control,
+    _Out_opt_ ULONG *BytesSent
+    );
+
+NTSTATUS
+WskSendToAsync(
+    PWSK_SOCKET Sock,
+    char *Buf,
+    ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool,
+    _In_ PSOCKADDR RemoteAddr,
+    ULONG ControlLen,
+    _In_opt_ PCMSGHDR Control,
+    _Out_ PVOID* SendCompletion
+    );
+
+NTSTATUS
+WskSendToAwait(
+    _Inout_ PVOID SendCompletion,
+    _In_ ULONG TimeoutMs,
+    _In_ ULONG ExpectedBytesSent,
+    _Out_opt_ ULONG *BytesSent
+    );
+
+NTSTATUS
+WskControlSocketSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    WSK_CONTROL_SOCKET_TYPE RequestType, // WskSetOption, WskGetOption or WskIoctl
+    ULONG ControlCode,
+    ULONG Level, // e.g. SOL_SOCKET
+    SIZE_T InputSize,
+    PVOID InputBuf,
+    SIZE_T OutputSize,
+    _Out_opt_ PVOID OutputBuf,
+    _Out_opt_ SIZE_T *OutputSizeReturned
+    );
+
+NTSTATUS
+WskGetLocalAddrSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    PSOCKADDR Addr
+    );
+
+NTSTATUS
+WskGetRemoteAddrSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    PSOCKADDR Addr
+    );
+
+NTSTATUS
+WskEnableCallbacks(
+    PWSK_SOCKET Sock,
+    int SockType,
+    ULONG EventMask
+    );
+
+EXTERN_C_END

--- a/src/sock/km/sock.c
+++ b/src/sock/km/sock.c
@@ -117,7 +117,8 @@ FnSockCreate(
     *Socket = NULL;
 
     Binding =
-        (FNSOCK_SOCKET_BINDING*)ExAllocatePoolZero(
+#pragma warning( suppress : 4996 )
+        (FNSOCK_SOCKET_BINDING*)ExAllocatePoolWithTag(
             NonPagedPoolNx, sizeof(*Binding), FNSOCK_POOL_SOCKET);
     if (Binding == NULL) {
         TraceError(
@@ -405,7 +406,8 @@ FnSockSendto(
     UNREFERENCED_PARAMETER(AddressLength);
 
     SendContext =
-        (FNSOCK_SOCKET_SEND_CONTEXT*)ExAllocatePoolZero(
+#pragma warning( suppress : 4996 )
+        (FNSOCK_SOCKET_SEND_CONTEXT*)ExAllocatePoolWithTag(
             NonPagedPoolNx, sizeof(*SendContext), FNSOCK_POOL_SOCKET_SEND);
     if (SendContext == NULL) {
         TraceError(
@@ -597,7 +599,8 @@ FnSockDatagramSocketReceive(
 
         FNSOCK_SOCKET_RECV_DATA* RecvData = NULL;
         RecvData =
-            (FNSOCK_SOCKET_RECV_DATA*)ExAllocatePoolZero(
+#pragma warning( suppress : 4996 )
+            (FNSOCK_SOCKET_RECV_DATA*)ExAllocatePoolWithTag(
                 NonPagedPoolNx, sizeof(*RecvData) + DataLength, FNSOCK_POOL_SOCKET_RECV);
         if (RecvData == NULL) {
             TraceError(

--- a/src/sock/um/sock.c
+++ b/src/sock/um/sock.c
@@ -168,11 +168,14 @@ FnSockSendto(
     _In_ FNSOCK_HANDLE Socket,
     _In_reads_bytes_(BufferLength) const CHAR* Buffer,
     _In_ INT BufferLength,
+    _In_ BOOLEAN BufferIsNonPagedPool,
     _In_ INT Flags,
     _In_reads_bytes_(AddressLength) const struct sockaddr* Address,
     _In_ INT AddressLength
     )
 {
+    UNREFERENCED_PARAMETER(BufferIsNonPagedPool);
+
     return sendto((SOCKET)Socket, Buffer, BufferLength, Flags, Address, AddressLength);
 }
 
@@ -182,9 +185,12 @@ FnSockRecv(
     _In_ FNSOCK_HANDLE Socket,
     _Out_writes_bytes_to_(BufferLength, return) CHAR* Buffer,
     _In_ INT BufferLength,
+    _In_ BOOLEAN BufferIsNonPagedPool,
     _In_ INT Flags
     )
 {
+    UNREFERENCED_PARAMETER(BufferIsNonPagedPool);
+
     return recv((SOCKET)Socket, Buffer, BufferLength, Flags);
 }
 

--- a/src/wskclient/wskclient.c
+++ b/src/wskclient/wskclient.c
@@ -1,0 +1,1822 @@
+#include <ntddk.h>
+#include <wsk.h>
+#include "wskclient.h"
+
+#define LOG(x, ...) DbgPrint((x), __VA_ARGS__)
+
+static const WSK_CLIENT_DISPATCH WskAppDispatch = {MAKE_WSK_VERSION(1,0), 0, NULL};
+static WSK_REGISTRATION Registration;
+static WSK_CLIENT_NPI ClientNpi;
+static WSK_PROVIDER_NPI ProviderNpi;
+
+NTSTATUS
+WskClientReg(
+    VOID
+    )
+{
+    NTSTATUS Status;
+    ClientNpi.ClientContext = NULL;
+    ClientNpi.Dispatch = &WskAppDispatch;
+    Status = WskRegister(&ClientNpi, &Registration);
+    if (!NT_SUCCESS(Status)) {
+        LOG("WskRegister failed with %d\n", Status);
+        goto Fail;
+    }
+    Status = WskCaptureProviderNPI(&Registration, WSK_NO_WAIT, &ProviderNpi);
+    if (!NT_SUCCESS(Status)) {
+        LOG("WskCaptureProviderNPI failed with %d\n", Status);
+        goto Deregister;
+    }
+
+    return Status;
+
+Deregister:
+    WskDeregister(&Registration);
+Fail:
+    return Status;
+}
+
+VOID
+WskClientDereg(
+    VOID
+    )
+{
+    WskReleaseProviderNPI(&Registration);
+    WskDeregister(&Registration);
+}
+
+static
+_Function_class_(IO_COMPLETION_ROUTINE)
+NTSTATUS
+GenericCompletionRoutine(
+    const DEVICE_OBJECT* DeviceObject,
+    const IRP* Irp,
+    PVOID Context
+    )
+{
+    PKEVENT Event = (PKEVENT)Context;
+    UNREFERENCED_PARAMETER(DeviceObject);
+    if (Irp->PendingReturned) {
+        KeSetEvent(Event, 0, FALSE);
+    }
+    return STATUS_MORE_PROCESSING_REQUIRED;
+}
+
+NTSTATUS
+WskWaitForIrpCompletion(
+    PKEVENT Event,
+    PIRP Irp,
+    ULONG TimeoutMs
+    )
+{
+    NTSTATUS Status;
+    LARGE_INTEGER Timeout;
+    LARGE_INTEGER* TimeoutPtr = NULL;
+
+    if (TimeoutMs != WSKCLIENT_INFINITE) {
+        Timeout.QuadPart = UInt32x32To64(TimeoutMs, 10000);
+        Timeout.QuadPart = -Timeout.QuadPart;
+        TimeoutPtr = &Timeout;
+    }
+
+    Status = KeWaitForSingleObject(Event, Executive, KernelMode, FALSE, TimeoutPtr);
+    if (Status == STATUS_TIMEOUT) {
+        IoCancelIrp(Irp);
+        KeWaitForSingleObject(Event, Executive, KernelMode, FALSE, NULL);
+    }
+
+    return Irp->IoStatus.Status;
+}
+
+NTSTATUS
+WskSocketSync(
+    int WskSockType,
+    ADDRESS_FAMILY Family,
+    USHORT SockType,
+    IPPROTO Protocol,
+    _Out_ PWSK_SOCKET* Sock,
+    _In_opt_ PVOID Context,
+    _In_opt_ PVOID Dispatch
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    KEVENT Event;
+
+    *Sock = NULL;
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+    Status =
+        ProviderNpi.Dispatch->WskSocket(
+            ProviderNpi.Client, Family, SockType, Protocol,
+            WskSockType, Context, Dispatch, NULL, NULL, NULL, Irp);
+    if (Status == STATUS_PENDING) {
+        Status = KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+    } else if (!NT_SUCCESS(Status)) {
+        LOG("WskSocket failed with %d\n", Status);
+        goto IoStatus;
+    }
+    *Sock = (PWSK_SOCKET)Irp->IoStatus.Information;
+IoStatus:
+    Status = Irp->IoStatus.Status;
+    IoFreeIrp(Irp);
+    return Status;
+}
+
+NTSTATUS
+WskSocketConnectSync(
+    USHORT SockType,
+    IPPROTO Protocol,
+    PSOCKADDR LocalAddr,
+    PSOCKADDR RemoteAddr,
+    _Out_ PWSK_SOCKET* Sock,
+    _In_opt_ PVOID Context,
+    _In_opt_ WSK_CLIENT_CONNECTION_DISPATCH* Dispatch
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    KEVENT Event;
+
+    *Sock = NULL;
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+    Status =
+        ProviderNpi.Dispatch->WskSocketConnect(
+            ProviderNpi.Client, SockType, Protocol, LocalAddr, RemoteAddr,
+            0, Context, Dispatch, NULL, NULL, NULL, Irp);
+    if (Status == STATUS_PENDING) {
+        Status = KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+    } else if (!NT_SUCCESS(Status)) {
+        LOG("WskSocketConnect failed with %d\n", Status);
+        goto IoStatus;
+    }
+    *Sock = (PWSK_SOCKET)Irp->IoStatus.Information;
+IoStatus:
+    Status = Irp->IoStatus.Status;
+    IoFreeIrp(Irp);
+    return Status;
+}
+
+NTSTATUS
+WskBindSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    PSOCKADDR Addr
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    KEVENT Event;
+    PFN_WSK_BIND WskBind;
+
+    switch (SockType) {
+    case WSK_FLAG_CONNECTION_SOCKET:
+        WskBind = ((PWSK_PROVIDER_CONNECTION_DISPATCH)Sock->Dispatch)->WskBind;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskBind = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskBind;
+        break;
+    case WSK_FLAG_LISTEN_SOCKET:
+        WskBind = ((PWSK_PROVIDER_LISTEN_DISPATCH)Sock->Dispatch)->WskBind;
+        break;
+    case WSK_FLAG_DATAGRAM_SOCKET:
+        WskBind = ((PWSK_PROVIDER_DATAGRAM_DISPATCH)Sock->Dispatch)->WskBind;
+        break;
+    default:
+        ASSERT(FALSE);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+    Status = WskBind(Sock, Addr, 0, Irp);
+    if (Status == STATUS_PENDING) {
+        Status = KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+    } else if (!NT_SUCCESS(Status)) {
+        LOG("WskBind failed with %d\n", Status);
+    }
+    Status = Irp->IoStatus.Status;
+    IoFreeIrp(Irp);
+    return Status;
+}
+
+NTSTATUS
+WskListenSync(
+    PWSK_SOCKET Sock,
+    int SockType
+    )
+//
+// This function is used for listening with WSK stream sockets.
+//
+// If you need to create a socket and at the point of creation you know it
+// needs to be a listening socket, you can create a wsk listening socket
+// directly using WskSocketSync(WSK_FLAG_LISTEN_SOCKET, ...).
+//
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    KEVENT Event;
+    PFN_WSK_LISTEN WskListen;
+
+    UNREFERENCED_PARAMETER(SockType);
+
+    ASSERT(SockType == WSK_FLAG_STREAM_SOCKET);
+    WskListen = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskListen;
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+    Status = WskListen(Sock, Irp);
+    if (Status == STATUS_PENDING) {
+        Status = KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+    } else if (!NT_SUCCESS(Status)) {
+        LOG("WskListen failed with %d\n", Status);
+    }
+    Status = Irp->IoStatus.Status;
+    IoFreeIrp(Irp);
+    return Status;
+}
+
+NTSTATUS
+WskConnectSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    PSOCKADDR Addr
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    KEVENT Event;
+    PFN_WSK_CONNECT WskConnect;
+
+    switch (SockType) {
+    case WSK_FLAG_CONNECTION_SOCKET:
+        WskConnect = ((PWSK_PROVIDER_CONNECTION_DISPATCH)Sock->Dispatch)->WskConnect;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskConnect = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskConnect;
+        break;
+    default:
+        ASSERT(FALSE);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+    Status = WskConnect(Sock, Addr, 0, Irp);
+    if (Status == STATUS_PENDING) {
+        Status = KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+    } else if (!NT_SUCCESS(Status)) {
+        LOG("WskConnect failed with %d\n", Status);
+    }
+    Status = Irp->IoStatus.Status;
+    IoFreeIrp(Irp);
+    return Status;
+}
+
+NTSTATUS
+WskConnectExSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    PSOCKADDR Addr,
+    char *Buf,
+    ULONG BufLen
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    KEVENT Event;
+    PFN_WSK_CONNECT_EX WskConnectEx;
+    WSK_BUF WskBuf = {0};
+
+    switch (SockType) {
+    case WSK_FLAG_CONNECTION_SOCKET:
+        WskConnectEx = ((PWSK_PROVIDER_CONNECTION_DISPATCH)Sock->Dispatch)->WskConnectEx;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskConnectEx = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskConnectEx;
+        break;
+    default:
+        ASSERT(FALSE);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+
+    if (Buf != NULL) {
+        WskBuf.Mdl = IoAllocateMdl(Buf, BufLen, FALSE, FALSE, NULL);
+        MmBuildMdlForNonPagedPool(WskBuf.Mdl);
+        WskBuf.Offset = 0;
+        WskBuf.Length = BufLen;
+        Status = WskConnectEx(Sock, Addr, &WskBuf, 0, Irp);
+    } else {
+        Status = WskConnectEx(Sock, Addr, NULL, 0, Irp);
+    }
+
+    if (Status == STATUS_PENDING) {
+        Status = KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+    } else if (!NT_SUCCESS(Status)) {
+        LOG("WskConnectEx failed with %d\n", Status);
+    }
+    Status = Irp->IoStatus.Status;
+    IoFreeIrp(Irp);
+    if (Buf != NULL) {
+        IoFreeMdl(WskBuf.Mdl);
+    }
+    return Status;
+}
+
+NTSTATUS
+WskConnectExAsync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    PSOCKADDR Addr,
+    char *Buf,
+    ULONG BufLen,
+    _Out_ PVOID* ConnectCompletion
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    PFN_WSK_CONNECT_EX WskConnectEx;
+    PWSKCONNECTEX_COMPLETION Completion;
+
+    // On success, caller must follow up with a call to WskConnectExAwait
+    // (regardless of whether the call was pended). If the call was pended, the
+    // client can instead call WskConnectExCancel.
+
+    #pragma warning( suppress : 4996 )
+    Completion = ExAllocatePoolWithTag(NonPagedPoolNx, sizeof(*Completion), 'tseT');
+    if (Completion == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    RtlZeroMemory(Completion, sizeof(*Completion));
+
+    switch (SockType) {
+    case WSK_FLAG_CONNECTION_SOCKET:
+        WskConnectEx = ((PWSK_PROVIDER_CONNECTION_DISPATCH)Sock->Dispatch)->WskConnectEx;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskConnectEx = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskConnectEx;
+        break;
+    default:
+        ASSERT(FALSE);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        ExFreePool(Completion);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Completion->Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Completion->Event, TRUE, TRUE, TRUE);
+
+    if (Buf != NULL) {
+        Completion->WskBuf.Mdl = IoAllocateMdl(Buf, BufLen, FALSE, FALSE, NULL);
+        MmBuildMdlForNonPagedPool(Completion->WskBuf.Mdl);
+        Completion->WskBuf.Offset = 0;
+        Completion->WskBuf.Length = BufLen;
+        Status = WskConnectEx(Sock, Addr, &Completion->WskBuf, 0, Irp);
+    } else {
+        Status = WskConnectEx(Sock, Addr, NULL, 0, Irp);
+    }
+    if (NT_SUCCESS(Status)) {
+        // N.B. This includes the STATUS_PENDING case.
+        Completion->Status = Status;
+        Completion->Irp = Irp;
+        Status = STATUS_SUCCESS;
+        *ConnectCompletion = Completion;
+    } else {
+        LOG("WskConnectEx failed with %d\n", Status);
+        IoFreeIrp(Irp);
+        if (Buf != NULL) {
+            IoFreeMdl(Completion->WskBuf.Mdl);
+        }
+        ExFreePool(Completion);
+    }
+
+    return Status;
+}
+
+NTSTATUS
+WskConnectExAwait(
+    _Inout_ PVOID ConnectCompletion,
+    _In_ ULONG TimeoutMs
+    )
+{
+    PWSKCONNECTEX_COMPLETION Completion = (PWSKCONNECTEX_COMPLETION)ConnectCompletion;
+    NTSTATUS Status = Completion->Status;
+    PIRP Irp = Completion->Irp;
+
+    ASSERT(NT_SUCCESS(Completion->Status));
+
+    if (Completion->Status == STATUS_PENDING) {
+        Status = WskWaitForIrpCompletion(&Completion->Event, Irp, TimeoutMs);
+    }
+
+    if (Status == STATUS_CANCELLED) {
+        // We hit our Timeout and cancelled the Irp. STATUS_TIMEOUT is a better
+        // Status in this case.
+        Status = STATUS_TIMEOUT;
+    }
+    IoFreeIrp(Irp);
+    if (Completion->WskBuf.Mdl != NULL) {
+        IoFreeMdl(Completion->WskBuf.Mdl);
+    }
+    ExFreePool(Completion);
+    return Status;
+}
+
+VOID
+WskConnectExCancel(
+    _Inout_ PVOID ConnectCompletion
+    )
+{
+    PWSKCONNECTEX_COMPLETION Completion = (PWSKCONNECTEX_COMPLETION)ConnectCompletion;
+    PIRP Irp = Completion->Irp;
+    IoCancelIrp(Irp);
+    KeWaitForSingleObject(&Completion->Event, Executive, KernelMode, FALSE, NULL);
+    IoFreeIrp(Irp);
+
+    if (Completion->WskBuf.Mdl != NULL) {
+        IoFreeMdl(Completion->WskBuf.Mdl);
+    }
+
+    ExFreePool(Completion);
+}
+
+NTSTATUS
+WskAcceptSync(
+    PWSK_SOCKET ListenSock,
+    int SockType,
+    ULONG TimeoutMs,
+    _Out_ PWSK_SOCKET* AcceptSock
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    KEVENT Event;
+    PFN_WSK_ACCEPT WskAccept;
+
+    switch (SockType) {
+    case WSK_FLAG_LISTEN_SOCKET:
+        WskAccept = ((PWSK_PROVIDER_LISTEN_DISPATCH)ListenSock->Dispatch)->WskAccept;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskAccept = ((PWSK_PROVIDER_STREAM_DISPATCH)ListenSock->Dispatch)->WskAccept;
+        break;
+    default:
+        ASSERT(FALSE);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+    Status = WskAccept(ListenSock, 0, NULL, NULL, NULL, NULL, Irp);
+    if (Status == STATUS_PENDING) {
+        Status = WskWaitForIrpCompletion(&Event, Irp, TimeoutMs);
+    }
+
+    if (NT_SUCCESS(Status)) {
+        *AcceptSock = (PWSK_SOCKET)Irp->IoStatus.Information;
+    } else {
+        LOG("WskAccept failed with %d\n", Status);
+    }
+
+    IoFreeIrp(Irp);
+    return Status;
+}
+
+NTSTATUS
+WskAcceptAsync(
+    PWSK_SOCKET ListenSock,
+    int SockType,
+    _Out_ PVOID* AcceptCompletion
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    PFN_WSK_ACCEPT WskAccept;
+    PWSKACCEPT_COMPLETION Completion;
+
+    // On success, caller must follow up with a call to WskAcceptAwait
+    // (regardless of whether the call was pended).
+
+    #pragma warning( suppress : 4996 )
+    Completion = ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(*Completion), 'tseT');
+    if (Completion == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    switch (SockType) {
+    case WSK_FLAG_LISTEN_SOCKET:
+        WskAccept = ((PWSK_PROVIDER_LISTEN_DISPATCH)ListenSock->Dispatch)->WskAccept;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskAccept = ((PWSK_PROVIDER_STREAM_DISPATCH)ListenSock->Dispatch)->WskAccept;
+        break;
+    default:
+        ASSERT(FALSE);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        ExFreePool(Completion);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Completion->Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Completion->Event, TRUE, TRUE, TRUE);
+    Status = WskAccept(ListenSock, 0, NULL, NULL, NULL, NULL, Irp);
+    if (NT_SUCCESS(Status)) {
+        // N.B. This includes the STATUS_PENDING case.
+        Completion->Status = Status;
+        Completion->Irp = Irp;
+        Status = STATUS_SUCCESS;
+        *AcceptCompletion = Completion;
+    } else {
+        LOG("WskAccept failed with %d\n", Status);
+        ExFreePool(Completion);
+    }
+
+    return Status;
+}
+
+NTSTATUS
+WskAcceptAwait(
+    PVOID AcceptCompletion,
+    ULONG TimeoutMs,
+    _Out_ PWSK_SOCKET* AcceptSock
+    )
+{
+    PWSKACCEPT_COMPLETION Completion = (PWSKACCEPT_COMPLETION)AcceptCompletion;
+    NTSTATUS Status = Completion->Status;
+    PIRP Irp = Completion->Irp;
+
+    ASSERT(NT_SUCCESS(Completion->Status));
+
+    *AcceptSock = NULL;
+
+    if (Completion->Status == STATUS_PENDING) {
+        Status = WskWaitForIrpCompletion(&Completion->Event, Irp, TimeoutMs);
+    }
+
+    if (NT_SUCCESS(Status)) {
+        *AcceptSock = (PWSK_SOCKET)Irp->IoStatus.Information;
+    } else if (Status == STATUS_CANCELLED) {
+        // We hit our Timeout and cancelled the Irp. STATUS_TIMEOUT is a better
+        // Status in this case.
+        Status = STATUS_TIMEOUT;
+    }
+
+    IoFreeIrp(Irp);
+    ExFreePool(Completion);
+    return Status;
+}
+
+VOID
+WskAcceptCancel(
+    _Inout_ PVOID AcceptCompletion
+    )
+{
+    PWSKACCEPT_COMPLETION Completion = (PWSKACCEPT_COMPLETION)AcceptCompletion;
+    PIRP Irp = Completion->Irp;
+    IoCancelIrp(Irp);
+    KeWaitForSingleObject(&Completion->Event, Executive, KernelMode, FALSE, NULL);
+    IoFreeIrp(Irp);
+    ExFreePool(Completion);
+}
+
+NTSTATUS
+WskCloseSocketSync(
+    PWSK_SOCKET Sock
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    KEVENT Event;
+    PFN_WSK_CLOSE_SOCKET WskCloseSocket;
+
+    WskCloseSocket = ((PWSK_PROVIDER_BASIC_DISPATCH)Sock->Dispatch)->WskCloseSocket;
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+    Status = WskCloseSocket(Sock, Irp);
+    if (Status == STATUS_PENDING) {
+        Status = KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+    } else if (!NT_SUCCESS(Status)) {
+        LOG("WskCloseSocket failed with %d\n", Status);
+    }
+    Status = Irp->IoStatus.Status;
+    IoFreeIrp(Irp);
+    return Status;
+}
+
+NTSTATUS
+WskDisconnectSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    char *Buf,
+    ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    KEVENT Event;
+    PFN_WSK_DISCONNECT WskDisconnect;
+    WSK_BUF WskBuf = {0};
+    BOOLEAN BufLocked = FALSE;
+
+    switch (SockType) {
+    case WSK_FLAG_CONNECTION_SOCKET:
+        WskDisconnect = ((PWSK_PROVIDER_CONNECTION_DISPATCH)Sock->Dispatch)->WskDisconnect;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskDisconnect = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskDisconnect;
+        break;
+    default:
+        ASSERT(FALSE);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+    if (Buf != NULL) {
+        WskBuf.Mdl = IoAllocateMdl(Buf, BufLen, FALSE, FALSE, NULL);
+        if (BufIsNonPagedPool) {
+            MmBuildMdlForNonPagedPool(WskBuf.Mdl);
+        } else {
+            try {
+                MmProbeAndLockPages(WskBuf.Mdl, KernelMode, IoWriteAccess);
+            } except(EXCEPTION_EXECUTE_HANDLER) {
+                LOG("MmProbeAndLockPages failed\n");
+                Status = STATUS_INSUFFICIENT_RESOURCES;
+                goto Cleanup;
+            }
+            BufLocked = TRUE;
+        }
+        WskBuf.Offset = 0;
+        WskBuf.Length = BufLen;
+        Status = WskDisconnect(Sock, &WskBuf, 0, Irp);
+    } else {
+        Status = WskDisconnect(Sock, NULL, 0, Irp);
+    }
+    if (Status == STATUS_PENDING) {
+        Status = KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+    } else if (!NT_SUCCESS(Status)) {
+        LOG("WskDisconnect failed with %d\n", Status);
+    }
+    Status = Irp->IoStatus.Status;
+Cleanup:
+    if (BufLocked) {
+        MmUnlockPages(WskBuf.Mdl);
+    }
+    IoFreeIrp(Irp);
+    if (Buf != NULL) {
+        IoFreeMdl(WskBuf.Mdl);
+    }
+    return Status;
+}
+
+NTSTATUS
+WskAbortSync(
+    PWSK_SOCKET Sock,
+    int SockType
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    KEVENT Event;
+    PFN_WSK_DISCONNECT WskDisconnect;
+
+    switch (SockType) {
+    case WSK_FLAG_CONNECTION_SOCKET:
+        WskDisconnect = ((PWSK_PROVIDER_CONNECTION_DISPATCH)Sock->Dispatch)->WskDisconnect;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskDisconnect = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskDisconnect;
+        break;
+    default:
+        ASSERT(FALSE);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+    Status = WskDisconnect(Sock, NULL, WSK_FLAG_ABORTIVE, Irp);
+    if (Status == STATUS_PENDING) {
+        Status = KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+    } else if (!NT_SUCCESS(Status)) {
+        LOG("WskDisconnect failed with %d\n", Status);
+    }
+    Status = Irp->IoStatus.Status;
+    IoFreeIrp(Irp);
+    return Status;
+}
+
+NTSTATUS
+WskDisconnectAsync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    char *Buf,
+    ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool,
+    ULONG Flags,
+    _Out_ PWSKDISCONNECT_COMPLETION* DisconnectCompletion
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    PFN_WSK_DISCONNECT WskDisconnect;
+    PWSKDISCONNECT_COMPLETION Completion;
+
+    // On success, caller must follow up with a call to WskDisconnectAwait,
+
+    #pragma warning( suppress : 4996 )
+    Completion = ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(*Completion), 'tseT');
+    if (Completion == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    RtlZeroMemory(Completion, sizeof(*Completion));
+
+    switch (SockType) {
+    case WSK_FLAG_CONNECTION_SOCKET:
+        WskDisconnect = ((PWSK_PROVIDER_CONNECTION_DISPATCH)Sock->Dispatch)->WskDisconnect;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskDisconnect = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskDisconnect;
+        break;
+    default:
+        ASSERT(FALSE);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        ExFreePool(Completion);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Completion->Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Completion->Event, TRUE, TRUE, TRUE);
+
+    if (Buf != NULL) {
+        ASSERT(Flags == 0);
+        Completion->WskBuf.Mdl = IoAllocateMdl(Buf, BufLen, FALSE, FALSE, NULL);
+        if (BufIsNonPagedPool) {
+            MmBuildMdlForNonPagedPool(Completion->WskBuf.Mdl);
+        } else {
+            try {
+                MmProbeAndLockPages(Completion->WskBuf.Mdl, KernelMode, IoWriteAccess);
+            } except(EXCEPTION_EXECUTE_HANDLER) {
+                LOG("MmProbeAndLockPages failed\n");
+                Status = STATUS_INSUFFICIENT_RESOURCES;
+                goto Failure;
+            }
+            Completion->BufLocked = TRUE;
+        }
+        Completion->WskBuf.Offset = 0;
+        Completion->WskBuf.Length = BufLen;
+        Status = WskDisconnect(Sock, &Completion->WskBuf, Flags, Irp);
+    } else {
+        Status = WskDisconnect(Sock, NULL, Flags, Irp);
+    }
+
+    if (NT_SUCCESS(Status)) {
+        // N.B. This includes the STATUS_PENDING case.
+        Completion->Status = Status;
+        Completion->Irp = Irp;
+        Status = STATUS_SUCCESS;
+        *DisconnectCompletion = Completion;
+        return Status;
+    }
+
+    LOG("WskDisconnect failed with %d\n", Status);
+Failure:
+    if (Completion->BufLocked) {
+        MmUnlockPages(Completion->WskBuf.Mdl);
+    }
+    IoFreeIrp(Irp);
+    if (Completion->WskBuf.Mdl != NULL) {
+        IoFreeMdl(Completion->WskBuf.Mdl);
+    }
+    ExFreePool(Completion);
+
+    return Status;
+}
+
+NTSTATUS
+WskDisconnectAwait(
+    _Inout_ PWSKDISCONNECT_COMPLETION Completion,
+    _In_ ULONG TimeoutMs
+    )
+{
+    NTSTATUS Status = Completion->Status;
+    PIRP Irp = Completion->Irp;
+
+    ASSERT(NT_SUCCESS(Completion->Status));
+
+    if (Completion->Status == STATUS_PENDING) {
+        Status = WskWaitForIrpCompletion(&Completion->Event, Irp, TimeoutMs);
+    }
+
+    if (Status == STATUS_CANCELLED) {
+        // We hit our Timeout and cancelled the Irp. STATUS_TIMEOUT is a better
+        // Status in this case.
+        Status = STATUS_TIMEOUT;
+    }
+
+    if (Completion->BufLocked) {
+        MmUnlockPages(Completion->WskBuf.Mdl);
+    }
+    IoFreeIrp(Irp);
+    if (Completion->WskBuf.Mdl != NULL) {
+        IoFreeMdl(Completion->WskBuf.Mdl);
+    }
+    ExFreePool(Completion);
+    return Status;
+}
+
+NTSTATUS
+WskSendSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    char *Buf,
+    ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool,
+    ULONG ExpectedBytesSent,
+    ULONG Flags,
+    _Out_opt_ ULONG *BytesSent
+    )
+{
+    PIRP Irp = NULL;
+    NTSTATUS Status;
+    KEVENT Event;
+    PFN_WSK_SEND WskSend;
+    WSK_BUF WskBuf = {0};
+    BOOLEAN BufLocked = FALSE;
+
+#if !DBG
+    UNREFERENCED_PARAMETER(ExpectedBytesSent);
+#endif
+
+    ASSERT(BufLen > 0);
+
+    WskBuf.Mdl = IoAllocateMdl(Buf, BufLen, FALSE, FALSE, NULL);
+    if (BufIsNonPagedPool) {
+        MmBuildMdlForNonPagedPool(WskBuf.Mdl);
+    } else {
+        try {
+            MmProbeAndLockPages(WskBuf.Mdl, KernelMode, IoWriteAccess);
+        } except(EXCEPTION_EXECUTE_HANDLER) {
+            LOG("MmProbeAndLockPages failed\n");
+            Status = STATUS_INSUFFICIENT_RESOURCES;
+            goto Cleanup;
+        }
+        BufLocked = TRUE;
+    }
+    WskBuf.Offset = 0;
+    WskBuf.Length = BufLen;
+
+    switch (SockType) {
+    case WSK_FLAG_CONNECTION_SOCKET:
+        WskSend = ((PWSK_PROVIDER_CONNECTION_DISPATCH)Sock->Dispatch)->WskSend;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskSend = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskSend;
+        break;
+    default:
+        ASSERT(FALSE);
+        Status = STATUS_UNSUCCESSFUL;
+        goto Cleanup;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto Cleanup;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+    Status = WskSend(Sock, &WskBuf, Flags, Irp);
+    if (Status == STATUS_PENDING) {
+        Status =
+            KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+    } else if (!NT_SUCCESS(Status)) {
+        LOG("WskSend failed with %d\n", Status);
+    }
+    Status = Irp->IoStatus.Status;
+    if (BytesSent != NULL) {
+        *BytesSent = (ULONG)Irp->IoStatus.Information;
+    }
+    if (ExpectedBytesSent != WSKCLIENT_UNKNOWN_BYTES) {
+        ASSERT((ULONG)Irp->IoStatus.Information == ExpectedBytesSent);
+    }
+Cleanup:
+    if (Irp != NULL) {
+        IoFreeIrp(Irp);
+    }
+    if (WskBuf.Mdl != NULL) {
+        if (BufLocked) {
+            MmUnlockPages(WskBuf.Mdl);
+        }
+        IoFreeMdl(WskBuf.Mdl);
+    }
+    return Status;
+}
+
+NTSTATUS
+WskSendExSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    char *Buf,
+    ULONG BufLen,
+    char* Control,
+    ULONG ControlLen,
+    ULONG ExpectedBytesSent,
+    ULONG Flags,
+    _Out_opt_ ULONG *BytesSent
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    KEVENT Event;
+    PFN_WSK_SEND_EX WskSendEx;
+    WSK_BUF WskBuf;
+
+#if !DBG
+    UNREFERENCED_PARAMETER(ExpectedBytesSent);
+#endif
+
+    ASSERT(BufLen > 0);
+
+    WskBuf.Mdl = IoAllocateMdl(Buf, BufLen, FALSE, FALSE, NULL);
+    MmBuildMdlForNonPagedPool(WskBuf.Mdl);
+    WskBuf.Offset = 0;
+    WskBuf.Length = BufLen;
+
+    switch (SockType) {
+    case WSK_FLAG_CONNECTION_SOCKET:
+        WskSendEx = ((PWSK_PROVIDER_CONNECTION_DISPATCH)Sock->Dispatch)->WskSendEx;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskSendEx = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskSendEx;
+        break;
+    default:
+        ASSERT(FALSE);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+    Status = WskSendEx(Sock, &WskBuf, Flags, ControlLen, (PCMSGHDR)Control, Irp);
+    if (Status == STATUS_PENDING) {
+        Status =
+            KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+    } else if (!NT_SUCCESS(Status)) {
+        LOG("WskSendEx failed with %d\n", Status);
+    }
+    Status = Irp->IoStatus.Status;
+    if (BytesSent != NULL) {
+        *BytesSent = (ULONG)Irp->IoStatus.Information;
+    }
+    if (ExpectedBytesSent != WSKCLIENT_UNKNOWN_BYTES) {
+        ASSERT((ULONG)Irp->IoStatus.Information == ExpectedBytesSent);
+    }
+    IoFreeIrp(Irp);
+    IoFreeMdl(WskBuf.Mdl);
+    return Status;
+}
+
+NTSTATUS
+WskSendAsync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    char *Buf,
+    ULONG BufLen,
+    ULONG Flags,
+    _Out_ PVOID* SendCompletion
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    PFN_WSK_SEND WskSend;
+    PWSKIOREQUEST_COMPLETION Completion;
+    ASSERT(BufLen > 0);
+
+    // On success, caller must follow up with a call to WskSendAwait.
+
+    #pragma warning( suppress : 4996 )
+    Completion = ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(*Completion), 'tseT');
+    if (Completion == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    RtlZeroMemory(Completion, sizeof(*Completion));
+
+    switch (SockType) {
+    case WSK_FLAG_CONNECTION_SOCKET:
+        WskSend = ((PWSK_PROVIDER_CONNECTION_DISPATCH)Sock->Dispatch)->WskSend;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskSend = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskSend;
+        break;
+    default:
+        ASSERT(FALSE);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        ExFreePool(Completion);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Completion->Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Completion->Event, TRUE, TRUE, TRUE);
+
+    Completion->WskBuf.Mdl = IoAllocateMdl(Buf, BufLen, FALSE, FALSE, NULL);
+    MmBuildMdlForNonPagedPool(Completion->WskBuf.Mdl);
+    Completion->WskBuf.Offset = 0;
+    Completion->WskBuf.Length = BufLen;
+
+    Status = WskSend(Sock, &Completion->WskBuf, Flags, Irp);
+
+    if (NT_SUCCESS(Status)) {
+        // N.B. This includes the STATUS_PENDING case.
+        Completion->Status = Status;
+        Completion->Irp = Irp;
+        Status = STATUS_SUCCESS;
+        *SendCompletion = Completion;
+    } else {
+        LOG("WskSend failed with %d\n", Status);
+        IoFreeIrp(Irp);
+        if (Completion->WskBuf.Mdl != NULL) {
+            IoFreeMdl(Completion->WskBuf.Mdl);
+        }
+        ExFreePool(Completion);
+    }
+
+    return Status;
+}
+
+NTSTATUS
+WskSendAwait(
+    _Inout_ PVOID SendCompletion,
+    _In_ ULONG TimeoutMs,
+    _In_ ULONG ExpectedBytesSent,
+    _Out_opt_ ULONG *BytesSent
+    )
+{
+#if !DBG
+    UNREFERENCED_PARAMETER(ExpectedBytesSent);
+#endif
+
+    PWSKIOREQUEST_COMPLETION Completion = (PWSKIOREQUEST_COMPLETION)SendCompletion;
+    NTSTATUS Status = Completion->Status;
+    PIRP Irp = Completion->Irp;
+
+    ASSERT(NT_SUCCESS(Completion->Status));
+
+    if (BytesSent != NULL) {
+        *BytesSent = 0;
+    }
+
+    if (Completion->Status == STATUS_PENDING) {
+        Status = WskWaitForIrpCompletion(&Completion->Event, Irp, TimeoutMs);
+    }
+
+    if (!NT_SUCCESS(Status))
+    {
+        LOG("WskSend IO failed with %d\n", Status);
+        if (Status == STATUS_CANCELLED)
+        {
+            // We hit our Timeout and cancelled the Irp. STATUS_TIMEOUT is a better
+            // Status in this case.
+            Status = STATUS_TIMEOUT;
+        }
+    }
+    else
+    {
+        if (BytesSent != NULL) {
+            *BytesSent = (ULONG)Irp->IoStatus.Information;
+        }
+        if (ExpectedBytesSent != WSKCLIENT_UNKNOWN_BYTES) {
+            ASSERT((ULONG)Irp->IoStatus.Information == ExpectedBytesSent);
+        }
+    }
+
+    IoFreeIrp(Irp);
+    if (Completion->WskBuf.Mdl != NULL) {
+        if (Completion->BufLocked) {
+            MmUnlockPages(Completion->WskBuf.Mdl);
+        }
+        IoFreeMdl(Completion->WskBuf.Mdl);
+    }
+    ExFreePool(Completion);
+    return Status;
+}
+
+NTSTATUS
+WskReceiveSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    char *Buf,
+    ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool,
+    ULONG ExpectedBytesReceived,
+    ULONG TimeoutMs,
+    _Out_opt_ ULONG *BytesReceived
+    )
+{
+    PIRP Irp = NULL;
+    NTSTATUS Status;
+    KEVENT Event;
+    PFN_WSK_RECEIVE WskReceive = NULL;
+    PFN_WSK_RECEIVE_FROM WskReceiveFrom = NULL;
+    WSK_BUF WskBuf = {0};
+    BOOLEAN BufLocked = FALSE;
+
+#if !DBG
+    UNREFERENCED_PARAMETER(ExpectedBytesReceived);
+#endif
+
+    ASSERT(BufLen > 0);
+
+    if (BytesReceived != NULL) {
+        *BytesReceived = 0;
+    }
+
+    WskBuf.Mdl = IoAllocateMdl(Buf, BufLen, FALSE, FALSE, NULL);
+    if (BufIsNonPagedPool) {
+        MmBuildMdlForNonPagedPool(WskBuf.Mdl);
+    } else {
+        try {
+            MmProbeAndLockPages(WskBuf.Mdl, KernelMode, IoWriteAccess);
+        } except(EXCEPTION_EXECUTE_HANDLER) {
+            LOG("MmProbeAndLockPages failed\n");
+            Status = STATUS_INSUFFICIENT_RESOURCES;
+            goto Cleanup;
+        }
+        BufLocked = TRUE;
+    }
+    WskBuf.Offset = 0;
+    WskBuf.Length = BufLen;
+
+    switch (SockType) {
+    case WSK_FLAG_CONNECTION_SOCKET:
+        WskReceive = ((PWSK_PROVIDER_CONNECTION_DISPATCH)Sock->Dispatch)->WskReceive;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskReceive = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskReceive;
+        break;
+    case WSK_FLAG_DATAGRAM_SOCKET:
+        WskReceiveFrom = ((PWSK_PROVIDER_DATAGRAM_DISPATCH)Sock->Dispatch)->WskReceiveFrom;
+        break;
+    default:
+        ASSERT(FALSE);
+        Status = STATUS_UNSUCCESSFUL;
+        goto Cleanup;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto Cleanup;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+
+    if (SockType == WSK_FLAG_DATAGRAM_SOCKET) {
+        ULONG ControlLen = 0;
+        Status = WskReceiveFrom(Sock, &WskBuf, 0, NULL, &ControlLen, NULL, NULL, Irp);
+    } else {
+        Status = WskReceive(Sock, &WskBuf, WSK_FLAG_WAITALL, Irp);
+    }
+
+    if (Status == STATUS_PENDING) {
+        Status = WskWaitForIrpCompletion(&Event, Irp, TimeoutMs);
+    }
+
+    if (NT_SUCCESS(Status)) {
+        if (BytesReceived != NULL) {
+            *BytesReceived = (ULONG)Irp->IoStatus.Information;
+        }
+        if (ExpectedBytesReceived != WSKCLIENT_UNKNOWN_BYTES) {
+            ASSERT((ULONG)Irp->IoStatus.Information == ExpectedBytesReceived);
+        }
+    } else {
+        LOG("WskReceive failed with %d\n", Status);
+        if (Status == STATUS_CANCELLED) {
+            // We hit our Timeout and cancelled the Irp. STATUS_TIMEOUT is a better
+            // Status in this case.
+            Status = STATUS_TIMEOUT;
+        }
+    }
+Cleanup:
+    if (Irp != NULL) {
+        IoFreeIrp(Irp);
+    }
+    if (WskBuf.Mdl != NULL) {
+        if (BufLocked) {
+            MmUnlockPages(WskBuf.Mdl);
+        }
+        IoFreeMdl(WskBuf.Mdl);
+    }
+    return Status;
+}
+
+NTSTATUS
+WskReceiveExSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    char *Buf,
+    ULONG BufLen,
+    PCMSGHDR Control,
+    PULONG ControlLen,
+    ULONG ExpectedBytesReceived,
+    ULONG TimeoutMs,
+    _Out_opt_ ULONG *BytesReceived
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    KEVENT Event;
+    PFN_WSK_RECEIVE_EX WskReceiveEx;
+    WSK_BUF WskBuf;
+
+#if !DBG
+    UNREFERENCED_PARAMETER(ExpectedBytesReceived);
+#endif
+
+    ASSERT(BufLen > 0);
+
+    if (BytesReceived != NULL) {
+        *BytesReceived = 0;
+    }
+
+    WskBuf.Mdl = IoAllocateMdl(Buf, BufLen, FALSE, FALSE, NULL);
+    MmBuildMdlForNonPagedPool(WskBuf.Mdl);
+    WskBuf.Offset = 0;
+    WskBuf.Length = BufLen;
+
+    switch (SockType) {
+    case WSK_FLAG_CONNECTION_SOCKET:
+        WskReceiveEx = ((PWSK_PROVIDER_CONNECTION_DISPATCH)Sock->Dispatch)->WskReceiveEx;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskReceiveEx = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskReceiveEx;
+        break;
+    default:
+        ASSERT(FALSE);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+
+    Status = WskReceiveEx(Sock, &WskBuf, WSK_FLAG_WAITALL, ControlLen, Control, NULL, Irp);
+
+    if (Status == STATUS_PENDING) {
+        Status = WskWaitForIrpCompletion(&Event, Irp, TimeoutMs);
+    }
+
+    if (NT_SUCCESS(Status)) {
+        if (BytesReceived != NULL) {
+            *BytesReceived = (ULONG)Irp->IoStatus.Information;
+        }
+        if (ExpectedBytesReceived != WSKCLIENT_UNKNOWN_BYTES) {
+            ASSERT((ULONG)Irp->IoStatus.Information == ExpectedBytesReceived);
+        }
+    } else {
+        LOG("WskReceiveEx failed with %d\n", Status);
+        if (Status == STATUS_CANCELLED) {
+            // We hit our Timeout and cancelled the Irp. STATUS_TIMEOUT is a better
+            // Status in this case.
+            Status = STATUS_TIMEOUT;
+        }
+    }
+
+    IoFreeIrp(Irp);
+    IoFreeMdl(WskBuf.Mdl);
+    return Status;
+}
+
+NTSTATUS
+WskReceiveAsync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    char *Buf,
+    ULONG BufLen,
+    _Out_ PVOID* ReceiveCompletion
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    PFN_WSK_RECEIVE WskReceive;
+    PWSKIOREQUEST_COMPLETION Completion;
+    ASSERT(BufLen > 0);
+
+    // On success, caller must follow up with a call to WskSendAwait.
+
+    #pragma warning( suppress : 4996 )
+    Completion = ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(*Completion), 'tseT');
+    if (Completion == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    RtlZeroMemory(Completion, sizeof(*Completion));
+
+    switch (SockType) {
+    case WSK_FLAG_CONNECTION_SOCKET:
+        WskReceive = ((PWSK_PROVIDER_CONNECTION_DISPATCH)Sock->Dispatch)->WskReceive;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskReceive = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskReceive;
+        break;
+    default:
+        ASSERT(FALSE);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        ExFreePool(Completion);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Completion->Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Completion->Event, TRUE, TRUE, TRUE);
+
+    Completion->WskBuf.Mdl = IoAllocateMdl(Buf, BufLen, FALSE, FALSE, NULL);
+    MmBuildMdlForNonPagedPool(Completion->WskBuf.Mdl);
+    Completion->WskBuf.Offset = 0;
+    Completion->WskBuf.Length = BufLen;
+
+    Status = WskReceive(Sock, &Completion->WskBuf, WSK_FLAG_WAITALL, Irp);
+
+    if (NT_SUCCESS(Status)) {
+        // N.B. This includes the STATUS_PENDING case.
+        Completion->Status = Status;
+        Completion->Irp = Irp;
+        Status = STATUS_SUCCESS;
+        *ReceiveCompletion = Completion;
+    } else {
+        LOG("WskReceive failed with %d\n", Status);
+        IoFreeIrp(Irp);
+        if (Completion->WskBuf.Mdl != NULL) {
+            IoFreeMdl(Completion->WskBuf.Mdl);
+        }
+        ExFreePool(Completion);
+    }
+
+    return Status;
+}
+
+NTSTATUS
+WskReceiveAwait(
+    _Inout_ PVOID ReceiveCompletion,
+    _In_ ULONG TimeoutMs,
+    _In_ ULONG ExpectedBytesReceived,
+    _Out_opt_ ULONG *BytesReceived
+    )
+{
+#if !DBG
+    UNREFERENCED_PARAMETER(ExpectedBytesReceived);
+#endif
+
+    PWSKIOREQUEST_COMPLETION Completion = (PWSKIOREQUEST_COMPLETION)ReceiveCompletion;
+    NTSTATUS Status = Completion->Status;
+    PIRP Irp = Completion->Irp;
+
+    ASSERT(NT_SUCCESS(Completion->Status));
+
+    if (BytesReceived != NULL) {
+        *BytesReceived = 0;
+    }
+
+    if (Completion->Status == STATUS_PENDING) {
+        Status = WskWaitForIrpCompletion(&Completion->Event, Irp, TimeoutMs);
+    }
+
+    if (!NT_SUCCESS(Status))
+    {
+        if (Status == STATUS_CANCELLED)
+        {
+            // We hit our Timeout and cancelled the Irp. STATUS_TIMEOUT is a better
+            // Status in this case.
+            Status = STATUS_TIMEOUT;
+        }
+
+        LOG("WskReceive IO failed with %d\n", Status);
+    }
+    else
+    {
+        if (BytesReceived != NULL) {
+            *BytesReceived = (ULONG)Irp->IoStatus.Information;
+        }
+        if (ExpectedBytesReceived != WSKCLIENT_UNKNOWN_BYTES) {
+            ASSERT((ULONG)Irp->IoStatus.Information == ExpectedBytesReceived);
+        }
+    }
+
+    IoFreeIrp(Irp);
+    if (Completion->WskBuf.Mdl != NULL) {
+        IoFreeMdl(Completion->WskBuf.Mdl);
+    }
+    ExFreePool(Completion);
+    return Status;
+}
+
+NTSTATUS
+WskSendToSync(
+    PWSK_SOCKET Sock,
+    char *Buf,
+    ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool,
+    ULONG ExpectedBytesSent,
+    _In_ PSOCKADDR remoteaddr,
+    ULONG ControlLen,
+    _In_opt_ PCMSGHDR Control,
+    _Out_opt_ ULONG *BytesSent
+    )
+{
+    PIRP Irp = NULL;
+    NTSTATUS Status;
+    KEVENT Event;
+    PFN_WSK_SEND_TO WskSendTo;
+    WSK_BUF WskBuf = {0};
+    BOOLEAN BufLocked = FALSE;
+
+#if !DBG
+    UNREFERENCED_PARAMETER(ExpectedBytesSent);
+#endif
+
+    ASSERT(BufLen > 0);
+
+    WskBuf.Mdl = IoAllocateMdl(Buf, BufLen, FALSE, FALSE, NULL);
+    if (BufIsNonPagedPool) {
+        MmBuildMdlForNonPagedPool(WskBuf.Mdl);
+    } else {
+        try {
+            MmProbeAndLockPages(WskBuf.Mdl, KernelMode, IoWriteAccess);
+        } except(EXCEPTION_EXECUTE_HANDLER) {
+            LOG("MmProbeAndLockPages failed\n");
+            Status = STATUS_INSUFFICIENT_RESOURCES;
+            goto Cleanup;
+        }
+        BufLocked = TRUE;
+    }
+    WskBuf.Offset = 0;
+    WskBuf.Length = BufLen;
+
+    WskSendTo = ((PWSK_PROVIDER_DATAGRAM_DISPATCH)Sock->Dispatch)->WskSendTo;
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+    Status = WskSendTo(Sock, &WskBuf, 0, remoteaddr, ControlLen, Control, Irp);
+    if (Status == STATUS_PENDING) {
+        Status =
+            KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+    } else if (!NT_SUCCESS(Status)) {
+        LOG("WskSend failed with %d\n", Status);
+    }
+    Status = Irp->IoStatus.Status;
+    if (BytesSent != NULL) {
+        *BytesSent = (ULONG)Irp->IoStatus.Information;
+    }
+    if (ExpectedBytesSent != WSKCLIENT_UNKNOWN_BYTES) {
+        ASSERT((ULONG)Irp->IoStatus.Information == ExpectedBytesSent);
+    }
+Cleanup:
+    if (Irp != NULL) {
+        IoFreeIrp(Irp);
+    }
+    if (WskBuf.Mdl != NULL) {
+        if (BufLocked) {
+            MmUnlockPages(WskBuf.Mdl);
+        }
+        IoFreeMdl(WskBuf.Mdl);
+    }
+    return Status;
+}
+
+NTSTATUS
+WskSendToAsync(
+    PWSK_SOCKET Sock,
+    char *Buf,
+    ULONG BufLen,
+    BOOLEAN BufIsNonPagedPool,
+    _In_ PSOCKADDR RemoteAddr,
+    ULONG ControlLen,
+    _In_opt_ PCMSGHDR Control,
+    _Out_ PVOID* SendCompletion
+    )
+{
+    PIRP Irp = NULL;
+    NTSTATUS Status;
+    PFN_WSK_SEND_TO WskSendTo;
+    PWSKIOREQUEST_COMPLETION Completion = NULL;
+
+    // On success, caller must follow up with a call to WskSendToAwait.
+
+#if !DBG
+    UNREFERENCED_PARAMETER(ExpectedBytesSent);
+#endif
+
+    ASSERT(BufLen > 0);
+
+    #pragma warning( suppress : 4996 )
+    Completion = ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(*Completion), 'tseT');
+    if (Completion == NULL) {
+        LOG("ExAllocatePool2 failed\n");
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto Cleanup;
+    }
+    RtlZeroMemory(Completion, sizeof(*Completion));
+
+    Completion->WskBuf.Mdl = IoAllocateMdl(Buf, BufLen, FALSE, FALSE, NULL);
+    if (BufIsNonPagedPool) {
+        MmBuildMdlForNonPagedPool(Completion->WskBuf.Mdl);
+    } else {
+        try {
+            MmProbeAndLockPages(Completion->WskBuf.Mdl, KernelMode, IoWriteAccess);
+        } except(EXCEPTION_EXECUTE_HANDLER) {
+            LOG("MmProbeAndLockPages failed\n");
+            Status = STATUS_INSUFFICIENT_RESOURCES;
+            goto Cleanup;
+        }
+        Completion->BufLocked = TRUE;
+    }
+    Completion->WskBuf.Offset = 0;
+    Completion->WskBuf.Length = BufLen;
+
+    WskSendTo = ((PWSK_PROVIDER_DATAGRAM_DISPATCH)Sock->Dispatch)->WskSendTo;
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        LOG("IoAllocateIrp failed\n");
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto Cleanup;
+    }
+    KeInitializeEvent(&Completion->Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Completion->Event, TRUE, TRUE, TRUE);
+    Status = WskSendTo(Sock, &Completion->WskBuf, 0, RemoteAddr, ControlLen, Control, Irp);
+    if (!NT_SUCCESS(Status)) {
+        LOG("WskSendTo failed with %d\n", Status);
+        goto Cleanup;
+    }
+
+    // N.B. This includes the STATUS_PENDING case.
+    Completion->Status = Status;
+    Completion->Irp = Irp;
+    Status = STATUS_SUCCESS;
+    *SendCompletion = Completion;
+
+Cleanup:
+    if (!NT_SUCCESS(Status)) {
+        if (Completion != NULL) {
+            if (Irp != NULL) {
+                IoFreeIrp(Irp);
+            }
+            if (Completion->WskBuf.Mdl != NULL) {
+                if (Completion->BufLocked) {
+                    MmUnlockPages(Completion->WskBuf.Mdl);
+                }
+                IoFreeMdl(Completion->WskBuf.Mdl);
+            }
+            ExFreePool(Completion);
+        }
+    }
+    return Status;
+}
+
+NTSTATUS
+WskSendToAwait(
+    _Inout_ PVOID SendCompletion,
+    _In_ ULONG TimeoutMs,
+    _In_ ULONG ExpectedBytesSent,
+    _Out_opt_ ULONG *BytesSent
+    )
+{
+    return WskSendAwait(SendCompletion, TimeoutMs, ExpectedBytesSent, BytesSent);
+}
+
+NTSTATUS
+WskControlSocketSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    WSK_CONTROL_SOCKET_TYPE RequestType, // WskSetOption, WskGetOption or WskIoctl
+    ULONG ControlCode,
+    ULONG Level, // e.g. SOL_SOCKET
+    SIZE_T InputSize,
+    PVOID InputBuf,
+    SIZE_T OutputSize,
+    _Out_opt_ PVOID OutputBuf,
+    _Out_opt_ SIZE_T *OutputSizeReturned
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    KEVENT Event;
+    PFN_WSK_CONTROL_SOCKET WskControlSocket;
+
+    switch (SockType) {
+    case WSK_FLAG_CONNECTION_SOCKET:
+        WskControlSocket = ((PWSK_PROVIDER_CONNECTION_DISPATCH)Sock->Dispatch)->WskControlSocket;
+        break;
+    case WSK_FLAG_LISTEN_SOCKET:
+        WskControlSocket = ((PWSK_PROVIDER_LISTEN_DISPATCH)Sock->Dispatch)->WskControlSocket;
+        break;
+    case WSK_FLAG_DATAGRAM_SOCKET:
+        WskControlSocket = ((PWSK_PROVIDER_DATAGRAM_DISPATCH)Sock->Dispatch)->WskControlSocket;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskControlSocket = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskControlSocket;
+        break;
+    case WSK_FLAG_BASIC_SOCKET:
+        WskControlSocket = ((PWSK_PROVIDER_BASIC_DISPATCH)Sock->Dispatch)->WskControlSocket;
+        break;
+    default:
+        ASSERT(FALSE);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+    Status =
+        WskControlSocket(
+            Sock, RequestType, ControlCode, Level, InputSize, InputBuf,
+            OutputSize, OutputBuf, OutputSizeReturned, Irp);
+    if (Status == STATUS_PENDING) {
+        Status =
+            KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+    } else if (!NT_SUCCESS(Status)) {
+        LOG("WskControlSocket failed with %d\n", Status);
+    }
+    Status = Irp->IoStatus.Status;
+    if (OutputSizeReturned != NULL) {
+        *OutputSizeReturned = Irp->IoStatus.Information;
+    }
+    IoFreeIrp(Irp);
+    return Status;
+}
+
+NTSTATUS
+WskGetLocalAddrSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    PSOCKADDR Addr
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    KEVENT Event;
+    PFN_WSK_GET_LOCAL_ADDRESS WskGetLocalAddr;
+
+    switch (SockType) {
+    case WSK_FLAG_CONNECTION_SOCKET:
+        WskGetLocalAddr = ((PWSK_PROVIDER_CONNECTION_DISPATCH)Sock->Dispatch)->WskGetLocalAddress;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskGetLocalAddr = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskGetLocalAddress;
+        break;
+    case WSK_FLAG_LISTEN_SOCKET:
+        WskGetLocalAddr = ((PWSK_PROVIDER_LISTEN_DISPATCH)Sock->Dispatch)->WskGetLocalAddress;
+        break;
+    case WSK_FLAG_DATAGRAM_SOCKET:
+        WskGetLocalAddr = ((PWSK_PROVIDER_DATAGRAM_DISPATCH)Sock->Dispatch)->WskGetLocalAddress;
+        break;
+    default:
+        ASSERT(FALSE);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+    Status = WskGetLocalAddr(Sock, Addr, Irp);
+    if (Status == STATUS_PENDING) {
+        Status = KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+    } else if (!NT_SUCCESS(Status)) {
+        LOG("WskGetLocalAddr failed with %d\n", Status);
+    }
+    Status = Irp->IoStatus.Status;
+    IoFreeIrp(Irp);
+    return Status;
+}
+
+NTSTATUS
+WskGetRemoteAddrSync(
+    PWSK_SOCKET Sock,
+    int SockType,
+    PSOCKADDR Addr
+    )
+{
+    PIRP Irp;
+    NTSTATUS Status;
+    KEVENT Event;
+    PFN_WSK_GET_REMOTE_ADDRESS WskGetRemoteAddr;
+
+    switch (SockType) {
+    case WSK_FLAG_CONNECTION_SOCKET:
+        WskGetRemoteAddr = ((PWSK_PROVIDER_CONNECTION_DISPATCH)Sock->Dispatch)->WskGetRemoteAddress;
+        break;
+    case WSK_FLAG_STREAM_SOCKET:
+        WskGetRemoteAddr = ((PWSK_PROVIDER_STREAM_DISPATCH)Sock->Dispatch)->WskGetRemoteAddress;
+        break;
+    default:
+        ASSERT(FALSE);
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    Irp = IoAllocateIrp(1, FALSE);
+    if (Irp == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    KeInitializeEvent(&Event, NotificationEvent, FALSE);
+    IoSetCompletionRoutine(Irp, GenericCompletionRoutine, &Event, TRUE, TRUE, TRUE);
+    Status = WskGetRemoteAddr(Sock, Addr, Irp);
+    if (Status == STATUS_PENDING) {
+        Status = KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+    } else if (!NT_SUCCESS(Status)) {
+        LOG("WskGetRemoteAddr failed with %d\n", Status);
+    }
+    Status = Irp->IoStatus.Status;
+    IoFreeIrp(Irp);
+    return Status;
+}
+
+NTSTATUS
+WskEnableCallbacks(
+    PWSK_SOCKET Sock,
+    int SockType,
+    ULONG EventMask
+    )
+{
+    WSK_EVENT_CALLBACK_CONTROL Control = {0};
+    NTSTATUS Status;
+
+    Control.NpiId = &NPI_WSK_INTERFACE_ID;
+    Control.EventMask = EventMask;
+    Status = WskControlSocketSync(
+        Sock, SockType, WskSetOption, SO_WSK_EVENT_CALLBACK, SOL_SOCKET,
+        sizeof(WSK_EVENT_CALLBACK_CONTROL), &Control, 0, NULL, NULL);
+
+    return Status;
+}

--- a/src/wskclient/wskclient.c
+++ b/src/wskclient/wskclient.c
@@ -610,7 +610,7 @@ WskAcceptAsync(
     // (regardless of whether the call was pended).
 
     #pragma warning( suppress : 4996 )
-    Completion = ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(*Completion), 'tseT');
+    Completion = ExAllocatePoolWithTag(NonPagedPoolNx, sizeof(*Completion), 'tseT');
     if (Completion == NULL) {
         Status = STATUS_INSUFFICIENT_RESOURCES;
         goto Failure;
@@ -850,7 +850,7 @@ WskDisconnectAsync(
     // On success, caller must follow up with a call to WskDisconnectAwait,
 
     #pragma warning( suppress : 4996 )
-    Completion = ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(*Completion), 'tseT');
+    Completion = ExAllocatePoolWithTag(NonPagedPoolNx, sizeof(*Completion), 'tseT');
     if (Completion == NULL) {
         Status = STATUS_INSUFFICIENT_RESOURCES;
         goto Failure;
@@ -1107,7 +1107,7 @@ WskSendAsync(
     // On success, caller must follow up with a call to WskSendAwait.
 
     #pragma warning( suppress : 4996 )
-    Completion = ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(*Completion), 'tseT');
+    Completion = ExAllocatePoolWithTag(NonPagedPoolNx, sizeof(*Completion), 'tseT');
     if (Completion == NULL) {
         Status = STATUS_INSUFFICIENT_RESOURCES;
         goto Failure;
@@ -1414,7 +1414,7 @@ WskReceiveAsync(
     // On success, caller must follow up with a call to WskSendAwait.
 
     #pragma warning( suppress : 4996 )
-    Completion = ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(*Completion), 'tseT');
+    Completion = ExAllocatePoolWithTag(NonPagedPoolNx, sizeof(*Completion), 'tseT');
     if (Completion == NULL) {
         Status = STATUS_INSUFFICIENT_RESOURCES;
         goto Failure;
@@ -1605,7 +1605,7 @@ WskSendToAsync(
     ASSERT(BufLen > 0);
 
     #pragma warning( suppress : 4996 )
-    Completion = ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(*Completion), 'tseT');
+    Completion = ExAllocatePoolWithTag(NonPagedPoolNx, sizeof(*Completion), 'tseT');
     if (Completion == NULL) {
         Status = STATUS_INSUFFICIENT_RESOURCES;
         goto Failure;

--- a/src/wskclient/wskclient.c
+++ b/src/wskclient/wskclient.c
@@ -1607,7 +1607,6 @@ WskSendToAsync(
     #pragma warning( suppress : 4996 )
     Completion = ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(*Completion), 'tseT');
     if (Completion == NULL) {
-        LOG("ExAllocatePool2 failed\n");
         Status = STATUS_INSUFFICIENT_RESOURCES;
         goto Failure;
     }
@@ -1623,7 +1622,6 @@ WskSendToAsync(
     WskSendTo = ((PWSK_PROVIDER_DATAGRAM_DISPATCH)Sock->Dispatch)->WskSendTo;
     Irp = IoAllocateIrp(1, FALSE);
     if (Irp == NULL) {
-        LOG("IoAllocateIrp failed\n");
         Status = STATUS_INSUFFICIENT_RESOURCES;
         goto Failure;
     }

--- a/src/wskclient/wskclient.c
+++ b/src/wskclient/wskclient.c
@@ -1602,10 +1602,6 @@ WskSendToAsync(
 
     // On success, caller must follow up with a call to WskSendToAwait.
 
-#if !DBG
-    UNREFERENCED_PARAMETER(ExpectedBytesSent);
-#endif
-
     ASSERT(BufLen > 0);
 
     #pragma warning( suppress : 4996 )

--- a/src/wskclient/wskclient.c
+++ b/src/wskclient/wskclient.c
@@ -1,3 +1,8 @@
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+
 #include <ntddk.h>
 #include <wsk.h>
 #include "wskclient.h"

--- a/src/wskclient/wskclient.vcxproj
+++ b/src/wskclient/wskclient.vcxproj
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectGuid>{50f8f5ee-aa31-427f-9959-13de0d68bd06}</ProjectGuid>
+    <TargetName>wskclient</TargetName>
+    <UndockedType>drvlib</UndockedType>
+    <UndockedDir>$(SolutionDir)submodules\undocked\</UndockedDir>
+    <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
+    <UndockedSourceLink>true</UndockedSourceLink>
+  </PropertyGroup>
+  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
+  <Import Project="$(SolutionDir)src\wnt.cpp.props" />
+  <Import Project="$(SolutionDir)src\wnt.cpp.kernel.props" />
+  <ItemGroup>
+    <ClCompile Include="wskclient.c" />
+  </ItemGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>
+        $(SolutionDir)inc;
+        %(AdditionalIncludeDirectories)
+      </AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(UndockedDir)vs\windows.undocked.targets" />
+</Project>

--- a/test/functional/bin/km/fnfunctionaltestdrv.vcxproj
+++ b/test/functional/bin/km/fnfunctionaltestdrv.vcxproj
@@ -21,6 +21,9 @@
     <ProjectReference Include="$(SolutionDir)src\sock\km\fnsock_km.vcxproj">
       <Project>{ac661767-42c3-4525-8b90-d509a6048dc3}</Project>
     </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)src\wskclient\wskclient.vcxproj">
+      <Project>{50f8f5ee-aa31-427f-9959-13de0d68bd06}</Project>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="control.cpp" />

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -926,7 +926,7 @@ WaitForWfpQuarantine(
         RX_FRAME RxFrame;
         RxInitializeFrame(&RxFrame, If->GetQueueId(), UdpFrame, UdpFrameLength);
         if (SUCCEEDED(MpRxIndicateFrame(SharedMp, &RxFrame))) {
-            Bytes = FnSockRecv(UdpSocket.get(), RecvPayload, sizeof(RecvPayload), 0);
+            Bytes = FnSockRecv(UdpSocket.get(), RecvPayload, sizeof(RecvPayload), FALSE, 0);
         } else {
             Bytes = (DWORD)-1;
         }
@@ -1074,7 +1074,7 @@ MpBasicRx()
     TEST_FNMPAPI(MpRxIndicateFrame(SharedMp, &RxFrame));
     TEST_EQUAL(
         sizeof(UdpPayload),
-        FnSockRecv(UdpSocket.get(), RecvPayload, sizeof(RecvPayload), 0));
+        FnSockRecv(UdpSocket.get(), RecvPayload, sizeof(RecvPayload), FALSE, 0));
     TEST_TRUE(RtlEqualMemory(UdpPayload, RecvPayload, sizeof(UdpPayload)));
 }
 
@@ -1121,7 +1121,7 @@ MpBasicTx()
     TEST_EQUAL(
         (int)SendSize,
         FnSockSendto(
-            UdpSocket.get(), (PCHAR)UdpPayload, SendSize, 0,
+            UdpSocket.get(), (PCHAR)UdpPayload, SendSize, FALSE, 0,
             (PSOCKADDR)&RemoteAddr, sizeof(RemoteAddr)));
 
     auto MpTxFrame = MpTxAllocateAndGetFrame(SharedMp, 0);
@@ -1183,7 +1183,7 @@ MpBasicTx()
     TEST_EQUAL(
         (int)SendSize,
         FnSockSendto(
-            UdpSocket.get(), (PCHAR)UdpPayload, SendSize, 0,
+            UdpSocket.get(), (PCHAR)UdpPayload, SendSize, FALSE, 0,
             (PSOCKADDR)&RemoteAddr, sizeof(RemoteAddr)));
 
     MpTxFrame = MpTxAllocateAndGetFrame(SharedMp, 0);
@@ -1244,7 +1244,7 @@ MpBasicRxOffload()
     TEST_FNMPAPI(MpRxIndicateFrame(SharedMp, &RxFrame));
     TEST_EQUAL(
         sizeof(UdpPayload),
-        FnSockRecv(UdpSocket.get(), RecvPayload, sizeof(RecvPayload), 0));
+        FnSockRecv(UdpSocket.get(), RecvPayload, sizeof(RecvPayload), FALSE, 0));
     TEST_TRUE(RtlEqualMemory(UdpPayload, RecvPayload, sizeof(UdpPayload)));
 
     NDIS_OFFLOAD_PARAMETERS OffloadParams;
@@ -1262,7 +1262,7 @@ MpBasicRxOffload()
     TEST_FNMPAPI(MpRxIndicateFrame(SharedMp, &RxFrame));
     TEST_EQUAL(
         sizeof(UdpPayload),
-        FnSockRecv(UdpSocket.get(), RecvPayload, sizeof(RecvPayload), 0));
+        FnSockRecv(UdpSocket.get(), RecvPayload, sizeof(RecvPayload), FALSE, 0));
     TEST_TRUE(RtlEqualMemory(UdpPayload, RecvPayload, sizeof(UdpPayload)));
     RxFrame.Frame.Input.Checksum.Value = 0;
     UdpHdr->uh_sum--;
@@ -1282,7 +1282,7 @@ MpBasicRxOffload()
     TEST_FNMPAPI(MpRxIndicateFrame(SharedMp, &RxFrame));
     TEST_EQUAL(
         sizeof(UdpPayload),
-        FnSockRecv(UdpSocket.get(), RecvPayload, sizeof(RecvPayload), 0));
+        FnSockRecv(UdpSocket.get(), RecvPayload, sizeof(RecvPayload), FALSE, 0));
     TEST_TRUE(RtlEqualMemory(UdpPayload, RecvPayload, sizeof(UdpPayload)));
     RxFrame.Frame.Input.Checksum.Value = 0;
     IpHdr->HeaderChecksum--;
@@ -1322,7 +1322,7 @@ MpBasicTxOffload()
     TEST_EQUAL(
         (int)sizeof(UdpPayload),
         FnSockSendto(
-            UdpSocket.get(), (PCHAR)UdpPayload, sizeof(UdpPayload), 0,
+            UdpSocket.get(), (PCHAR)UdpPayload, sizeof(UdpPayload), FALSE, 0,
             (PSOCKADDR)&RemoteAddr, sizeof(RemoteAddr)));
 
     auto MpTxFrame = MpTxAllocateAndGetFrame(SharedMp, 0);
@@ -1339,7 +1339,7 @@ MpBasicTxOffload()
     TEST_EQUAL(
         (int)sizeof(UdpPayload),
         FnSockSendto(
-            UdpSocket.get(), (PCHAR)UdpPayload, sizeof(UdpPayload), 0,
+            UdpSocket.get(), (PCHAR)UdpPayload, sizeof(UdpPayload), FALSE, 0,
             (PSOCKADDR)&RemoteAddr, sizeof(RemoteAddr)));
 
     MpTxFrame = MpTxAllocateAndGetFrame(SharedMp, 0);

--- a/wnt.sln
+++ b/wnt.sln
@@ -37,6 +37,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fnsock_um", "src\sock\um\fn
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fnsock_km", "src\sock\km\fnsock_km.vcxproj", "{AC661767-42C3-4525-8B90-D509A6048DC3}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "wskclient", "src\wskclient\wskclient.vcxproj", "{50F8F5EE-AA31-427F-9959-13DE0D68BD06}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -241,6 +243,18 @@ Global
 		{AC661767-42C3-4525-8B90-D509A6048DC3}.Release|x64.ActiveCfg = Release|x64
 		{AC661767-42C3-4525-8B90-D509A6048DC3}.Release|x64.Build.0 = Release|x64
 		{AC661767-42C3-4525-8B90-D509A6048DC3}.Release|x64.Deploy.0 = Release|x64
+		{50F8F5EE-AA31-427F-9959-13DE0D68BD06}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{50F8F5EE-AA31-427F-9959-13DE0D68BD06}.Debug|ARM64.Build.0 = Debug|ARM64
+		{50F8F5EE-AA31-427F-9959-13DE0D68BD06}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{50F8F5EE-AA31-427F-9959-13DE0D68BD06}.Debug|x64.ActiveCfg = Debug|x64
+		{50F8F5EE-AA31-427F-9959-13DE0D68BD06}.Debug|x64.Build.0 = Debug|x64
+		{50F8F5EE-AA31-427F-9959-13DE0D68BD06}.Debug|x64.Deploy.0 = Debug|x64
+		{50F8F5EE-AA31-427F-9959-13DE0D68BD06}.Release|ARM64.ActiveCfg = Release|ARM64
+		{50F8F5EE-AA31-427F-9959-13DE0D68BD06}.Release|ARM64.Build.0 = Release|ARM64
+		{50F8F5EE-AA31-427F-9959-13DE0D68BD06}.Release|ARM64.Deploy.0 = Release|ARM64
+		{50F8F5EE-AA31-427F-9959-13DE0D68BD06}.Release|x64.ActiveCfg = Release|x64
+		{50F8F5EE-AA31-427F-9959-13DE0D68BD06}.Release|x64.Build.0 = Release|x64
+		{50F8F5EE-AA31-427F-9959-13DE0D68BD06}.Release|x64.Deploy.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Leverage the wskclient library from the OS tests to implement kernel mode fnsock instead of adding another WSK wrapper. Also, expose wskclient as another tool in the win-net-test tool bag. When we get time we can replace the OS version of wskclient with this version.