### PR TITLE
acquire LWF rundown before filtering NBLs

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major": 0, "minor": 4, "patch": 2 }
+{ "major": 0, "minor": 4, "patch": 3 }


### PR DESCRIPTION
NDIS requires LWFs return any NBLs they held on to before completing a pause request, so acquire a rundown reference before filtering.

https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ndis/nc-ndis-filter_pause

Also bump the version to 0.4.3 for a bugfix release.