### PR TITLE
Expose FnSock as dll/sys

### DIFF
--- a/inc/fnsock.h
+++ b/inc/fnsock.h
@@ -111,8 +111,13 @@ EXTERN_C_START
 
 #endif
 
+#ifndef FNSOCKAPI
+#define FNSOCKAPI __declspec(dllimport)
+#endif
+
 DECLARE_HANDLE(FNSOCK_HANDLE);
 
+FNSOCKAPI
 PAGEDX
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
@@ -120,6 +125,7 @@ FnSockInitialize(
     VOID
     );
 
+FNSOCKAPI
 PAGEDX
 _IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
@@ -127,6 +133,7 @@ FnSockUninitialize(
     VOID
     );
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockCreate(
@@ -136,12 +143,14 @@ FnSockCreate(
     _Out_ FNSOCK_HANDLE* Socket
     );
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
 FnSockClose(
     _In_ FNSOCK_HANDLE Socket
     );
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockBind(
@@ -150,6 +159,7 @@ FnSockBind(
     _In_ INT AddressLength
     );
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockGetSockName(
@@ -158,6 +168,7 @@ FnSockGetSockName(
     _Inout_ INT* AddressLength
     );
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockSetSockOpt(
@@ -168,6 +179,7 @@ FnSockSetSockOpt(
     _In_ SIZE_T OptionLength
     );
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockGetSockOpt(
@@ -178,6 +190,7 @@ FnSockGetSockOpt(
     _Inout_ SIZE_T* OptionLength
     );
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockIoctl(
@@ -190,6 +203,7 @@ FnSockIoctl(
     _Out_ ULONG* BytesReturned
     );
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockListen(
@@ -197,6 +211,7 @@ FnSockListen(
     _In_ ULONG Backlog
     );
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_HANDLE
 FnSockAccept(
@@ -205,6 +220,7 @@ FnSockAccept(
     _Inout_ INT* AddressLength
     );
 
+FNSOCKAPI
 FNSOCK_STATUS
 FnSockConnect(
     _In_ FNSOCK_HANDLE Socket,
@@ -212,6 +228,7 @@ FnSockConnect(
     _In_ INT AddressLength
     );
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 INT
 FnSockSend(
@@ -222,6 +239,7 @@ FnSockSend(
     _In_ INT Flags
     );
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 INT
 FnSockSendto(
@@ -234,6 +252,7 @@ FnSockSendto(
     _In_ INT AddressLength
     );
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 INT
 FnSockRecv(
@@ -244,6 +263,7 @@ FnSockRecv(
     _In_ INT Flags
     );
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 INT
 FnSockGetLastError(

--- a/src/sock/km/fnsock_km.def
+++ b/src/sock/km/fnsock_km.def
@@ -1,0 +1,5 @@
+LIBRARY fnsock_km.sys
+
+EXPORTS
+    DllInitialize PRIVATE
+    DllUnload PRIVATE

--- a/src/sock/km/fnsock_km.vcxproj
+++ b/src/sock/km/fnsock_km.vcxproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectGuid>{ac661767-42c3-4525-8b90-d509a6048dc3}</ProjectGuid>
     <TargetName>fnsock_km</TargetName>
-    <UndockedType>drvlib</UndockedType>
+    <UndockedType>sys</UndockedType>
     <UndockedDir>$(SolutionDir)submodules\undocked\</UndockedDir>
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
@@ -11,6 +11,11 @@
   <Import Project="$(UndockedDir)vs\windows.undocked.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.kernel.props" />
+  <ItemGroup>
+    <ProjectReference Include="$(SolutionDir)src\wskclient\wskclient.vcxproj">
+      <Project>{50f8f5ee-aa31-427f-9959-13de0d68bd06}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <ItemGroup>
     <ClCompile Include="sock.c" />
   </ItemGroup>
@@ -27,6 +32,14 @@
       <WppRecorderEnabled>true</WppRecorderEnabled>
       <WppAdditionalOptions>-p:fnsock</WppAdditionalOptions>
     </ClCompile>
+    <Link>
+      <ModuleDefinitionFile>fnsock_km.def</ModuleDefinitionFile>
+      <AdditionalDependencies>
+        netio.lib;
+        uuid.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
+    </Link>
   </ItemDefinitionGroup>
   <Import Project="$(UndockedDir)vs\windows.undocked.targets" />
 </Project>

--- a/src/sock/km/sock.c
+++ b/src/sock/km/sock.c
@@ -17,6 +17,8 @@
 #include <ntddk.h>
 #include <wsk.h>
 
+#define FNSOCKAPI __declspec(dllexport)
+
 #include "fnsock.h"
 #include "pooltag.h"
 #include "trace.h"
@@ -109,6 +111,38 @@ FnSockStreamSocketReceive(
     _Inout_ SIZE_T* BytesAccepted
     );
 
+_Function_class_(DRIVER_INITIALIZE)
+_IRQL_requires_same_
+_IRQL_requires_(PASSIVE_LEVEL)
+NTSTATUS
+DriverEntry(
+    _In_ struct _DRIVER_OBJECT *DriverObject,
+    _In_ UNICODE_STRING *RegistryPath
+    )
+{
+    UNREFERENCED_PARAMETER(DriverObject);
+    UNREFERENCED_PARAMETER(RegistryPath);
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+DllInitialize(
+    _In_ PUNICODE_STRING RegistryPath
+    )
+{
+    UNREFERENCED_PARAMETER(RegistryPath);
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+DllUnload(
+    VOID
+    )
+{
+    return STATUS_SUCCESS;
+}
+
+FNSOCKAPI
 PAGEDX
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
@@ -132,6 +166,7 @@ FnSockInitialize(
     return WskClientReg();
 }
 
+FNSOCKAPI
 PAGEDX
 _IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
@@ -169,6 +204,7 @@ InitializeBinding(
     InitializeListHead(&Binding->SendContextList);
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockCreate(
@@ -248,6 +284,7 @@ Exit:
     return Status;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
 FnSockClose(
@@ -325,6 +362,7 @@ FnSockClose(
     ExFreePoolWithTag(Binding, POOLTAG_FNSOCK_SOCKET);
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockBind(
@@ -380,6 +418,7 @@ Exit:
     return Status;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockGetSockName(
@@ -416,6 +455,7 @@ Exit:
     return Status;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockSetSockOpt(
@@ -474,6 +514,7 @@ Exit:
     return Status;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockGetSockOpt(
@@ -535,6 +576,7 @@ Exit:
     return Status;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockIoctl(
@@ -583,6 +625,7 @@ Exit:
     return Status;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockListen(
@@ -631,6 +674,7 @@ Exit:
     return Status;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_HANDLE
 FnSockAccept(
@@ -726,6 +770,7 @@ Exit:
     return (FNSOCK_HANDLE)NewBinding;
 }
 
+FNSOCKAPI
 FNSOCK_STATUS
 FnSockConnect(
     _In_ FNSOCK_HANDLE Socket,
@@ -794,6 +839,7 @@ Exit:
     return Status;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 INT
 FnSockSend(
@@ -872,6 +918,7 @@ Exit:
     return BytesSent;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 INT
 FnSockSendto(
@@ -954,6 +1001,7 @@ Exit:
     return BytesSent;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 INT
 FnSockRecv(
@@ -1497,6 +1545,7 @@ NtStatusToSocketError(
     return err;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 INT
 FnSockGetLastError(

--- a/src/sock/um/fnsock_um.vcxproj
+++ b/src/sock/um/fnsock_um.vcxproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectGuid>{dca385fb-b4b1-44cc-ba3f-9da4f619d86a}</ProjectGuid>
     <TargetName>fnsock_um</TargetName>
-    <UndockedType>lib</UndockedType>
+    <UndockedType>dll</UndockedType>
     <UndockedDir>$(SolutionDir)submodules\undocked\</UndockedDir>
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
@@ -26,6 +26,12 @@
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
     </ClCompile>
+    <Link>
+      <AdditionalDependencies>
+        ws2_32.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
+    </Link>
   </ItemDefinitionGroup>
   <Import Project="$(UndockedDir)vs\windows.undocked.targets" />
 </Project>

--- a/src/sock/um/sock.c
+++ b/src/sock/um/sock.c
@@ -8,11 +8,14 @@
 #include <winternl.h>
 #include <stdlib.h>
 
+#define FNSOCKAPI __declspec(dllexport)
+
 #include "fnsock.h"
 #include "trace.h"
 
 #include "sock.tmh"
 
+FNSOCKAPI
 PAGEDX
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
@@ -39,6 +42,7 @@ FnSockInitialize(
     return Status;
 }
 
+FNSOCKAPI
 PAGEDX
 _IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
@@ -49,6 +53,7 @@ FnSockUninitialize(
     WSACleanup();
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockCreate(
@@ -76,6 +81,7 @@ FnSockCreate(
     return Status;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 VOID
 FnSockClose(
@@ -85,6 +91,7 @@ FnSockClose(
     closesocket((SOCKET)Socket);
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockBind(
@@ -110,6 +117,7 @@ FnSockBind(
     return Status;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockGetSockName(
@@ -135,6 +143,7 @@ FnSockGetSockName(
     return Status;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockSetSockOpt(
@@ -162,6 +171,7 @@ FnSockSetSockOpt(
     return Status;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockGetSockOpt(
@@ -189,6 +199,7 @@ FnSockGetSockOpt(
     return Status;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockIoctl(
@@ -221,6 +232,7 @@ FnSockIoctl(
     return Status;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_STATUS
 FnSockListen(
@@ -245,6 +257,7 @@ FnSockListen(
     return Status;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 FNSOCK_HANDLE
 FnSockAccept(
@@ -271,6 +284,7 @@ FnSockAccept(
     return (FNSOCK_HANDLE)AcceptedSocket;
 }
 
+FNSOCKAPI
 FNSOCK_STATUS
 FnSockConnect(
     _In_ FNSOCK_HANDLE Socket,
@@ -295,6 +309,7 @@ FnSockConnect(
     return Status;
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 INT
 FnSockSend(
@@ -310,6 +325,7 @@ FnSockSend(
     return send((SOCKET)Socket, Buffer, BufferLength, Flags);
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 INT
 FnSockSendto(
@@ -327,6 +343,7 @@ FnSockSendto(
     return sendto((SOCKET)Socket, Buffer, BufferLength, Flags, Address, AddressLength);
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 INT
 FnSockRecv(
@@ -342,6 +359,7 @@ FnSockRecv(
     return recv((SOCKET)Socket, Buffer, BufferLength, Flags);
 }
 
+FNSOCKAPI
 _IRQL_requires_max_(PASSIVE_LEVEL)
 INT
 FnSockGetLastError(

--- a/test/functional/bin/km/fnfunctionaltestdrv.vcxproj
+++ b/test/functional/bin/km/fnfunctionaltestdrv.vcxproj
@@ -21,9 +21,6 @@
     <ProjectReference Include="$(SolutionDir)src\sock\km\fnsock_km.vcxproj">
       <Project>{ac661767-42c3-4525-8b90-d509a6048dc3}</Project>
     </ProjectReference>
-    <ProjectReference Include="$(SolutionDir)src\wskclient\wskclient.vcxproj">
-      <Project>{50f8f5ee-aa31-427f-9959-13de0d68bd06}</Project>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="control.cpp" />
@@ -43,8 +40,8 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>
+        $(OutDir)fnsock_km.lib;
         netio.lib;
-        uuid.lib;
         wdmsec.lib;
         %(AdditionalDependencies)
       </AdditionalDependencies>

--- a/tools/functional.ps1
+++ b/tools/functional.ps1
@@ -139,6 +139,10 @@ for ($i = 1; $i -le $Iterations; $i++) {
         & "$RootDir\tools\setup.ps1" -Install fnlwf -Config $Config -Arch $Arch
         Write-Verbose "installed fnlwf."
 
+        Write-Verbose "installing fnsock..."
+        & "$RootDir\tools\setup.ps1" -Install fnsock -Config $Config -Arch $Arch
+        Write-Verbose "installed fnsock."
+
         $TestArgs = @()
         if (![string]::IsNullOrEmpty($TestBinaryPath)) {
             $TestArgs += $TestBinaryPath
@@ -176,6 +180,7 @@ for ($i = 1; $i -le $Iterations; $i++) {
         if ($Watchdog -ne $null) {
             Remove-Job -Job $Watchdog -Force
         }
+        & "$RootDir\tools\setup.ps1" -Uninstall fnsock -Config $Config -Arch $Arch -ErrorAction 'Continue'
         & "$RootDir\tools\setup.ps1" -Uninstall fnlwf -Config $Config -Arch $Arch -ErrorAction 'Continue'
         & "$RootDir\tools\setup.ps1" -Uninstall fnmp -Config $Config -Arch $Arch -ErrorAction 'Continue'
         if ($KernelMode) {

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -158,8 +158,8 @@ if ($Cleanup) {
         $ForTest = $true
         # The NDIS verifier is required, otherwise allocations NDIS makes on
         # behalf of FNMP/FNLWF (e.g. NBLs) will not be verified.
-        Write-Verbose "verifier.exe /standard /driver fnmp.sys fnlwf.sys ndis.sys fnfunctionaltestdrv.sys isrdrv.sys"
-        verifier.exe /standard /driver fnmp.sys fnlwf.sys ndis.sys fnfunctionaltestdrv.sys isrdrv.sys | Write-Verbose
+        Write-Verbose "verifier.exe /standard /driver fnmp.sys fnlwf.sys ndis.sys fnfunctionaltestdrv.sys isrdrv.sys fnsock_km.sys"
+        verifier.exe /standard /driver fnmp.sys fnlwf.sys ndis.sys fnfunctionaltestdrv.sys isrdrv.sys fnsock_km.sys | Write-Verbose
         if (!$?) {
             $Reboot = $true
         }

--- a/tools/sign.ps1
+++ b/tools/sign.ps1
@@ -81,6 +81,7 @@ $FnLwfInf = Join-Path $FnLwfDir "fnlwf.inf"
 $FnLwfCat = Join-Path $FnLwfDir "fnlwf.cat"
 $FnFunctionalTestDrvSys = Join-Path $ArtifactsDir "fnfunctionaltestdrv.sys"
 $IsrDrvSys = Join-Path $ArtifactsDir "isrdrv.sys"
+$FnSockSys = Join-Path $ArtifactsDir "fnsock_km.sys"
 
 # Verify all the files are present.
 if (!(Test-Path $FnMpSys)) { Write-Error "$FnMpSys does not exist!" }
@@ -89,6 +90,7 @@ if (!(Test-Path $FnLwfSys)) { Write-Error "$FnLwfSys does not exist!" }
 if (!(Test-Path $FnLwfInf)) { Write-Error "$FnLwfInf does not exist!" }
 if (!(Test-Path $FnFunctionalTestDrvSys)) { Write-Error "$FnFunctionalTestDrvSys does not exist!" }
 if (!(Test-Path $IsrDrvSys)) { Write-Error "$IsrDrvSys does not exist!" }
+if (!(Test-Path $FnSockSys)) { Write-Error "$FnSockSys does not exist!" }
 
 # Sign the driver files.
 & $SignToolPath sign /f $CertPath -p "placeholder" /fd SHA256 $FnMpSys
@@ -98,6 +100,8 @@ if ($LastExitCode) { Write-Error "signtool.exe exit code: $LastExitCode" }
 & $SignToolPath sign /f $CertPath -p "placeholder" /fd SHA256 $FnFunctionalTestDrvSys
 if ($LastExitCode) { Write-Error "signtool.exe exit code: $LastExitCode" }
 & $SignToolPath sign /f $CertPath -p "placeholder" /fd SHA256 $IsrDrvSys
+if ($LastExitCode) { Write-Error "signtool.exe exit code: $LastExitCode" }
+& $SignToolPath sign /f $CertPath -p "placeholder" /fd SHA256 $FnSockSys
 if ($LastExitCode) { Write-Error "signtool.exe exit code: $LastExitCode" }
 
 # Build up the catalogs.


### PR DESCRIPTION
Expose FnSock as dll/sys libraries. This makes consumption more flexible compared to static libs (which brings in complexities such as libs compiled with different CRTs). The next step will be to package the headers and import libs into a nuget package that other projects can consume.