### PR TITLE
add offload options to task offload API

### DIFF
--- a/inc/fniotypes.h
+++ b/inc/fniotypes.h
@@ -152,4 +152,8 @@ typedef enum _FN_OFFLOAD_TYPE {
     FnOffloadHardwareCapabilities,
 } FN_OFFLOAD_TYPE;
 
+typedef struct _FN_OFFLOAD_OPTIONS {
+    UINT32 GsoMaxOffloadSize;
+} FN_OFFLOAD_OPTIONS;
+
 EXTERN_C_END

--- a/inc/fnmpapi.h
+++ b/inc/fnmpapi.h
@@ -378,12 +378,22 @@ FnMpOidCompleteRequest(
 }
 
 FNMPAPI
+VOID
+FnMpInitializeOffloadOptions(
+    _Out_ FN_OFFLOAD_OPTIONS *OffloadOptions
+    )
+{
+    RtlZeroMemory(OffloadOptions, sizeof(*OffloadOptions));
+}
+
+FNMPAPI
 FNMPAPI_STATUS
-FnMpUpdateTaskOffload(
+FnMpUpdateTaskOffload2(
     _In_ FNMP_HANDLE Handle,
     _In_ FN_OFFLOAD_TYPE OffloadType,
     _In_opt_ const NDIS_OFFLOAD_PARAMETERS *OffloadParameters,
-    _In_ UINT32 OffloadParametersLength
+    _In_ UINT32 OffloadParametersLength,
+    _In_opt_ FN_OFFLOAD_OPTIONS *OffloadOptions
     )
 {
     MINIPORT_UPDATE_TASK_OFFLOAD_IN In = {0};
@@ -396,13 +406,30 @@ FnMpUpdateTaskOffload(
     // configuration from the registry. If the offload parameters are specfied,
     // the miniport handles this as if it were set via OID.
     //
+    // The offload options optionally override the NIC's default capabilities.
+    //
 
     In.OffloadType = OffloadType;
     In.OffloadParameters = OffloadParameters;
     In.OffloadParametersLength = OffloadParametersLength;
+    In.OffloadOptions = OffloadOptions;
 
     return
         FnIoctl(Handle, FNMP_IOCTL_MINIPORT_UPDATE_TASK_OFFLOAD, &In, sizeof(In), NULL, 0, NULL, NULL);
+}
+
+FNMPAPI
+FNMPAPI_STATUS
+FnMpUpdateTaskOffload(
+    _In_ FNMP_HANDLE Handle,
+    _In_ FN_OFFLOAD_TYPE OffloadType,
+    _In_opt_ const NDIS_OFFLOAD_PARAMETERS *OffloadParameters,
+    _In_ UINT32 OffloadParametersLength
+    )
+{
+    return
+        FnMpUpdateTaskOffload2(
+            Handle, OffloadType, OffloadParameters, OffloadParametersLength, NULL);
 }
 
 EXTERN_C_END

--- a/inc/fnmpioctl.h
+++ b/inc/fnmpioctl.h
@@ -101,6 +101,7 @@ typedef struct _MINIPORT_UPDATE_TASK_OFFLOAD_IN {
     FN_OFFLOAD_TYPE OffloadType;
     const NDIS_OFFLOAD_PARAMETERS *OffloadParameters;
     UINT32 OffloadParametersLength;
+    const FN_OFFLOAD_OPTIONS *OffloadOptions;
 } MINIPORT_UPDATE_TASK_OFFLOAD_IN;
 
 EXTERN_C_END

--- a/src/mp/sys/miniport.c
+++ b/src/mp/sys/miniport.c
@@ -329,6 +329,15 @@ Exit:
 }
 
 static
+VOID
+MpInitializeOffload(
+    _Inout_ ADAPTER_OFFLOAD *Offload
+    )
+{
+    Offload->GsoMaxOffloadSize = MAX_GSO_SIZE;
+}
+
+static
 NDIS_STATUS
 MpReadConfiguration(
    _Inout_ ADAPTER_CONTEXT *Adapter
@@ -345,6 +354,8 @@ MpReadConfiguration(
     Adapter->MtuSize = FNMP_DEFAULT_MTU - ETH_HDR_LEN;
     Adapter->CurrentLookAhead = 0;
     Adapter->CurrentPacketFilter = 0;
+    MpInitializeOffload(&Adapter->OffloadCapabilities);
+    MpInitializeOffload(&Adapter->OffloadConfig);
 
     Adapter->RssEnabled = 0;
     TRY_READ_INT_CONFIGURATION(ConfigHandle, &RegRSS, &Adapter->RssEnabled);
@@ -452,13 +463,13 @@ MpFillOffload(
 
     if (AdapterOffload->LsoV2IPv4) {
         Offload->LsoV2.IPv4.Encapsulation = Encapsulation;
-        Offload->LsoV2.IPv4.MaxOffLoadSize = MAX_GSO_SIZE;
+        Offload->LsoV2.IPv4.MaxOffLoadSize = AdapterOffload->GsoMaxOffloadSize;
         Offload->LsoV2.IPv4.MinSegmentCount = MIN_GSO_SEG_COUNT;
     }
 
     if (AdapterOffload->LsoV2IPv6) {
         Offload->LsoV2.IPv6.Encapsulation = Encapsulation;
-        Offload->LsoV2.IPv6.MaxOffLoadSize = MAX_GSO_SIZE;
+        Offload->LsoV2.IPv6.MaxOffLoadSize = AdapterOffload->GsoMaxOffloadSize;
         Offload->LsoV2.IPv6.MinSegmentCount = MIN_GSO_SEG_COUNT;
         Offload->LsoV2.IPv6.IpExtensionHeadersSupported = NDIS_OFFLOAD_SUPPORTED;
         Offload->LsoV2.IPv6.TcpOptionsSupported = NDIS_OFFLOAD_SUPPORTED;
@@ -466,14 +477,14 @@ MpFillOffload(
 
     if (AdapterOffload->UsoIPv4) {
         Offload->UdpSegmentation.IPv4.Encapsulation = Encapsulation;
-        Offload->UdpSegmentation.IPv4.MaxOffLoadSize = MAX_GSO_SIZE;
+        Offload->UdpSegmentation.IPv4.MaxOffLoadSize = AdapterOffload->GsoMaxOffloadSize;
         Offload->UdpSegmentation.IPv4.MinSegmentCount = MIN_GSO_SEG_COUNT;
         Offload->UdpSegmentation.IPv4.SubMssFinalSegmentSupported = NDIS_OFFLOAD_SUPPORTED;
     }
 
     if (AdapterOffload->UsoIPv6) {
         Offload->UdpSegmentation.IPv6.Encapsulation = Encapsulation;
-        Offload->UdpSegmentation.IPv6.MaxOffLoadSize = MAX_GSO_SIZE;
+        Offload->UdpSegmentation.IPv6.MaxOffLoadSize = AdapterOffload->GsoMaxOffloadSize;
         Offload->UdpSegmentation.IPv6.MinSegmentCount = MIN_GSO_SEG_COUNT;
         Offload->UdpSegmentation.IPv6.IpExtensionHeadersSupported = NDIS_OFFLOAD_SUPPORTED;
         Offload->UdpSegmentation.IPv6.SubMssFinalSegmentSupported = NDIS_OFFLOAD_SUPPORTED;

--- a/src/mp/sys/miniport.h
+++ b/src/mp/sys/miniport.h
@@ -56,6 +56,7 @@ typedef struct _ADAPTER_OFFLOAD {
     UINT32 RscIPv4;
     UINT32 RscIPv6;
     UINT32 UdpRsc;
+    UINT32 GsoMaxOffloadSize;
 } ADAPTER_OFFLOAD;
 
 typedef struct _ADAPTER_CONTEXT {

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major": 0, "minor": 5, "patch": 1 }
+{ "major": 0, "minor": 5, "patch": 2 }


### PR DESCRIPTION
XDP needs a way to configure arbitrary task offload capabilities; not merely toggle them on and off.

Add a new, extensible options struct to a new API and thunk the old API.