### PR TITLE
automatically include includes in nuget props

### DIFF
--- a/tools/nuget/win-net-test.props
+++ b/tools/nuget/win-net-test.props
@@ -5,4 +5,9 @@
     <WntBinPath>$(MSBuildThisFileDirectory)bin</WntBinPath>
     <WntIncPath>$(MSBuildThisFileDirectory)include</WntIncPath>
   </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(WntIncPath)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
Most .props files automatically add includes to the include path, so do that. Don't add libraries, since many projects won't need to link the libraries, and we have both user and kernel mode variants.