### PR TITLE
Use _KERNEL_MODE instead

### DIFF
--- a/inc/fniotypes.h
+++ b/inc/fniotypes.h
@@ -10,7 +10,7 @@
 // functional test miniport/lwf (fnmp/fnlwf).
 //
 
-#ifndef KERNEL_MODE
+#ifndef _KERNEL_MODE
 //
 // This header depends on the following headers included in the following order.
 // However, it is most likely too late to include these headers by the time this

--- a/inc/fnlwfapi.h
+++ b/inc/fnlwfapi.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include <fniotypes.h>
-#if defined(KERNEL_MODE)
+#if defined(_KERNEL_MODE)
 #include <fnioctl_km.h>
 #include <fnlwfapistatus_km.h>
 #else

--- a/inc/fnmpapi.h
+++ b/inc/fnmpapi.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include <fniotypes.h>
-#if defined(KERNEL_MODE)
+#if defined(_KERNEL_MODE)
 #include <fnioctl_km.h>
 #include <fnmpapistatus_km.h>
 #else

--- a/inc/fnsock.h
+++ b/inc/fnsock.h
@@ -7,7 +7,7 @@
 
 EXTERN_C_START
 
-#if defined(KERNEL_MODE)
+#if defined(_KERNEL_MODE)
 #define FNSOCK_STATUS NTSTATUS
 #define FNSOCK_FAILED(X) !NT_SUCCESS(X)
 #define FNSOCK_SUCCEEDED(X) NT_SUCCESS(X)
@@ -16,7 +16,7 @@ EXTERN_C_START
 #ifndef PAGEDX
 #define PAGEDX __declspec(code_seg("PAGE"))
 #endif
-#else // defined(KERNEL_MODE)
+#else // defined(_KERNEL_MODE)
 #define FNSOCK_STATUS HRESULT
 #define FNSOCK_FAILED(X) FAILED(X)
 #define FNSOCK_SUCCEEDED(X) SUCCEEDED(X)
@@ -25,7 +25,7 @@ EXTERN_C_START
 #ifndef PAGEDX
 #define PAGEDX
 #endif
-#endif // defined(KERNEL_MODE)
+#endif // defined(_KERNEL_MODE)
 
 /*
  * WinSock error codes are also defined in winerror.h

--- a/inc/pkthlp.h
+++ b/inc/pkthlp.h
@@ -8,7 +8,7 @@
 #pragma warning(push)
 #pragma warning(disable:4201)  // nonstandard extension used: nameless struct/union
 
-#if defined(KERNEL_MODE) && !defined(htons)
+#if defined(_KERNEL_MODE) && !defined(htons)
 #define __pkthlp_htons
 #define htons RtlUshortByteSwap
 #define ntohs RtlUshortByteSwap
@@ -376,7 +376,7 @@ PktParseTcpFrame(
     return TRUE;
 }
 
-#ifndef KERNEL_MODE
+#ifndef _KERNEL_MODE
 inline
 BOOLEAN
 PktStringToInetAddressA(

--- a/src/common/inc/fnassert.h
+++ b/src/common/inc/fnassert.h
@@ -13,7 +13,7 @@
 #undef ASSERT
 #endif
 
-#ifdef KERNEL_MODE
+#ifdef _KERNEL_MODE
 #if DBG
 // Ensure the system bugchecks if KD is disabled.
 #define ASSERT(e) \
@@ -39,7 +39,7 @@
 #endif
 #endif
 
-#ifdef KERNEL_MODE
+#ifdef _KERNEL_MODE
 #define FRE_ASSERT(e) \
     (NT_VERIFY(e) ? TRUE : (RtlFailFast(FAST_FAIL_INVALID_ARG), FALSE))
 #elif DBG

--- a/src/common/inc/fnrtl.h
+++ b/src/common/inc/fnrtl.h
@@ -123,7 +123,7 @@ WriteUInt32NoFence(
 
 #endif
 
-#ifdef KERNEL_MODE
+#ifdef _KERNEL_MODE
 
 FORCEINLINE
 _IRQL_requires_max_(APC_LEVEL)

--- a/test/cxplat/inc/cxplat.h
+++ b/test/cxplat/inc/cxplat.h
@@ -13,7 +13,7 @@
 
 EXTERN_C_START
 
-#if defined(KERNEL_MODE)
+#if defined(_KERNEL_MODE)
 
 #define CXPLAT_STATUS NTSTATUS
 #define CXPLAT_FAILED(X) !NT_SUCCESS(X)
@@ -34,7 +34,7 @@ EXTERN_C_START
 // Use on pageable functions.
 #define PAGEDX __declspec(code_seg(KRTL_PAGE_SEGMENT))
 
-#else // defined(KERNEL_MODE)
+#else // defined(_KERNEL_MODE)
 
 #define CXPLAT_STATUS HRESULT
 #define CXPLAT_FAILED(X) FAILED(X)
@@ -43,7 +43,7 @@ EXTERN_C_START
 #define CXPLAT_STATUS_FAIL E_FAIL
 #define PAGEDX
 
-#endif // defined(KERNEL_MODE)
+#endif // defined(_KERNEL_MODE)
 
 PAGEDX
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -136,7 +136,7 @@ CxPlatFreeNoTag(
 
 DECLARE_HANDLE(CXPLAT_THREAD);
 
-#if defined(KERNEL_MODE)
+#if defined(_KERNEL_MODE)
 typedef VOID CXPLAT_THREAD_RETURN_TYPE;
 #define CXPLAT_THREAD_RETURN(Status) PsTerminateSystemThread(Status)
 #else

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 //
 
-#if defined(KERNEL_MODE)
+#if defined(_KERNEL_MODE)
 #include <ntddk.h>
 #include <ntintsafe.h>
 #include <ntstrsafe.h>
@@ -35,7 +35,7 @@
 #include <pkthlp.h>
 #include <fnmpapi.h>
 #include <fnlwfapi.h>
-#if defined(KERNEL_MODE)
+#if defined(_KERNEL_MODE)
 #include <invokesystemrelay.h>
 #endif
 #include <qeo_ndis.h>
@@ -84,7 +84,7 @@ using unique_fnlwf_handle = wil::unique_any<FNLWF_HANDLE, decltype(::FnLwfClose)
 using unique_fnsock_handle = wil::unique_any<FNSOCK_HANDLE, decltype(::FnSockClose), ::FnSockClose>;
 using unique_cxplat_thread = wil::unique_any<CXPLAT_THREAD, decltype(::CxPlatThreadDelete), ::CxPlatThreadDelete>;
 
-#if defined(KERNEL_MODE)
+#if defined(_KERNEL_MODE)
 #define TEST_FNMPAPI TEST_NTSTATUS
 #define TEST_FNLWFAPI TEST_NTSTATUS
 #define TEST_FNMPAPI_GOTO TEST_NTSTATUS_GOTO
@@ -107,7 +107,7 @@ using unique_cxplat_thread = wil::unique_any<CXPLAT_THREAD, decltype(::CxPlatThr
 #define TEST_FNLWFAPI_RET TEST_HRESULT_RET
 #define RtlStringCbPrintfA(Dst, DstSize, Format, ...) \
     sprintf_s(Dst, Format, __VA_ARGS__)
-#endif // defined(KERNEL_MODE)
+#endif // defined(_KERNEL_MODE)
 
 static CONST CHAR *PowershellPrefix = "powershell -noprofile -ExecutionPolicy Bypass";
 static CONST CHAR *FirewallAddRuleString = "netsh advfirewall firewall add rule name=fnmptest dir=in action=allow protocol=any remoteip=any localip=any";
@@ -1646,7 +1646,7 @@ SockBasicTcp(
     SIZE_T OptLen = sizeof(Opt);
     TEST_CXPLAT(FnSockGetSockOpt(ClientSocket.get(), IPPROTO_TCP, TCP_KEEPCNT, &Opt, &OptLen));
 
-#ifndef KERNEL_MODE
+#ifndef _KERNEL_MODE
     LINGER lingerInfo;
     lingerInfo.l_onoff = 1;
     lingerInfo.l_linger = 0;

--- a/test/functional/testframeworkapi.h
+++ b/test/functional/testframeworkapi.h
@@ -10,7 +10,7 @@
 // use different test frameworks without changing test logic.
 //
 
-#if !defined(KERNEL_MODE)
+#if !defined(_KERNEL_MODE)
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
_KERNEL_MODE is set by default by msbuild when compiling KM drivers. No need to rely on KERNEL_MODE which is set in windows.undocked.props (undocked submodule).

After cleaning this up, we can get rid of KERNEL_MODE flag in XDP as well.