### PR TITLE
fix a few NBL leaks

### DIFF
--- a/src/common/lib/fnio/enqueue.c
+++ b/src/common/lib/fnio/enqueue.c
@@ -110,6 +110,12 @@ FnIoEnqueueFrameBegin(
 
 Exit:
 
+    if (!NT_SUCCESS(Status)) {
+        if (Nbl != NULL) {
+            FnIoEnqueueFrameReturn(Nbl);
+        }
+    }
+
     return Status;
 }
 

--- a/src/mp/sys/rx.c
+++ b/src/mp/sys/rx.c
@@ -246,6 +246,8 @@ SharedIrpRxFlush(
         KeLowerIrql(OldIrql);
     }
 
+    Status = STATUS_SUCCESS;
+
     if (In->Options.Flags.LowResources) {
         NET_BUFFER_LIST *Nbl = NdisGetNblChainFromNblCountedQueue(&Nbls);
         UINT32 Count = 0;
@@ -258,7 +260,6 @@ SharedIrpRxFlush(
         while (Nbl != NULL) {
             if (NET_BUFFER_LIST_MINIPORT_RESERVED(Nbl)[0] != Nbl->Next) {
                 Status = STATUS_IO_DEVICE_ERROR;
-                goto Exit;
             }
 
             Nbl = Nbl->Next;
@@ -267,11 +268,10 @@ SharedIrpRxFlush(
 
         if (Count != (UINT32)Nbls.NblCount) {
             Status = STATUS_IO_DEVICE_ERROR;
-            goto Exit;
         }
-    }
 
-    Status = STATUS_SUCCESS;
+        SharedRxCleanupNblChain(NdisGetNblChainFromNblCountedQueue(&Nbls));
+    }
 
 Exit:
 


### PR DESCRIPTION
We're leaking NBLs in enqueue failure paths and the FNMP low resources RX path.