### PR TITLE
FNMP: make offload options extensible

### DIFF
--- a/inc/fnmpapi.h
+++ b/inc/fnmpapi.h
@@ -413,7 +413,7 @@ FnMpUpdateTaskOffload2(
     In.OffloadParameters = OffloadParameters;
     In.OffloadParametersLength = OffloadParametersLength;
     In.OffloadOptions = OffloadOptions;
-    In.OffloadOptionsLength = sizeof(*OffloadOptions);
+    In.OffloadOptionsLength = OffloadOptions != NULL ? sizeof(*OffloadOptions) : 0;
 
     return
         FnIoctl(Handle, FNMP_IOCTL_MINIPORT_UPDATE_TASK_OFFLOAD, &In, sizeof(In), NULL, 0, NULL, NULL);

--- a/inc/fnmpapi.h
+++ b/inc/fnmpapi.h
@@ -413,6 +413,7 @@ FnMpUpdateTaskOffload2(
     In.OffloadParameters = OffloadParameters;
     In.OffloadParametersLength = OffloadParametersLength;
     In.OffloadOptions = OffloadOptions;
+    In.OffloadOptionsLength = sizeof(*OffloadOptions);
 
     return
         FnIoctl(Handle, FNMP_IOCTL_MINIPORT_UPDATE_TASK_OFFLOAD, &In, sizeof(In), NULL, 0, NULL, NULL);

--- a/inc/fnmpioctl.h
+++ b/inc/fnmpioctl.h
@@ -102,6 +102,7 @@ typedef struct _MINIPORT_UPDATE_TASK_OFFLOAD_IN {
     const NDIS_OFFLOAD_PARAMETERS *OffloadParameters;
     UINT32 OffloadParametersLength;
     const FN_OFFLOAD_OPTIONS *OffloadOptions;
+    UINT32 OffloadOptionsLength;
 } MINIPORT_UPDATE_TASK_OFFLOAD_IN;
 
 EXTERN_C_END

--- a/src/mp/sys/shared.c
+++ b/src/mp/sys/shared.c
@@ -174,12 +174,12 @@ SharedIrpUpdateTaskOffload(
             NDIS_STATUS_TASK_OFFLOAD_CURRENT_CONFIG :
             NDIS_STATUS_TASK_OFFLOAD_HARDWARE_CAPABILITIES;
 
-    if (In->OffloadOptions != NULL) {
+    if (In->OffloadOptionsLength > 0) {
         FN_OFFLOAD_OPTIONS *Options;
 
         Status =
             BounceBuffer(
-                &OffloadOptions, Irp->RequestorMode, In->OffloadOptions, sizeof(*Options),
+                &OffloadOptions, Irp->RequestorMode, In->OffloadOptions, In->OffloadOptionsLength,
                 __alignof(FN_OFFLOAD_OPTIONS));
         if (!NT_SUCCESS(Status)) {
             goto Exit;
@@ -189,7 +189,8 @@ SharedIrpUpdateTaskOffload(
 
         RtlAcquirePushLockExclusive(&Adapter->PushLock);
 
-        if (Options->GsoMaxOffloadSize != 0) {
+        if (In->OffloadOptionsLength >= RTL_SIZEOF_THROUGH_FIELD(FN_OFFLOAD_OPTIONS, GsoMaxOffloadSize) &&
+            Options->GsoMaxOffloadSize != 0) {
             MpGetOffload(Adapter, In->OffloadType)->GsoMaxOffloadSize = Options->GsoMaxOffloadSize;
         }
 


### PR DESCRIPTION
I realized #87 is not seamlessly extensible if we add more fields to the options structs; we should not require apps be recompiled to use newer versions of the FNMPAPI.

add an implicit size field to the IOCTL.