### PR TITLE
Add support for filtering OIDs by port numbers

### DIFF
--- a/inc/fniotypes.h
+++ b/inc/fniotypes.h
@@ -137,10 +137,17 @@ typedef enum _FNIO_OID_REQUEST_INTERFACE {
 // Helper type used by parameters for OID related IOCTLs.
 //
 
+typedef struct _OID_KEY_V0 {
+    NDIS_OID Oid;
+    NDIS_REQUEST_TYPE RequestType;
+    OID_REQUEST_INTERFACE RequestInterface;
+} OID_KEY_V0;
+
 typedef struct _OID_KEY {
     NDIS_OID Oid;
     NDIS_REQUEST_TYPE RequestType;
     OID_REQUEST_INTERFACE RequestInterface;
+    NDIS_PORT_NUMBER PortNumber;
 } OID_KEY;
 
 //

--- a/inc/fnlwfapi.h
+++ b/inc/fnlwfapi.h
@@ -259,7 +259,7 @@ FnLwfOidSubmitRequest(
     // Issues an OID and waits for completion.
     //
 
-    In.Key = Key;
+    In.Key = &Key;
     In.InformationBuffer = InformationBuffer;
     In.InformationBufferLength = *InformationBufferLength;
 

--- a/inc/fnlwfioctl.h
+++ b/inc/fnlwfioctl.h
@@ -7,7 +7,7 @@
 
 EXTERN_C_START
 
-#define FNLWF_IOCTL_CURRENT_VERSION 1
+#define FNLWF_IOCTL_CURRENT_VERSION 2
 
 #define FNLWF_DEVICE_NAME L"\\Device\\fnlwf"
 
@@ -58,8 +58,14 @@ typedef struct _FNLWF_OPEN_DEFAULT {
 // Parameters for FNLWF_IOCTL_OID_SUBMIT_REQUEST.
 //
 
+typedef struct _OID_SUBMIT_REQUEST_IN_V0 {
+    OID_KEY_V0 Key;
+    VOID *InformationBuffer;
+    UINT32 InformationBufferLength;
+} OID_SUBMIT_REQUEST_IN_V0;
+
 typedef struct _OID_SUBMIT_REQUEST_IN {
-    OID_KEY Key;
+    const OID_KEY *Key;
     VOID *InformationBuffer;
     UINT32 InformationBufferLength;
 } OID_SUBMIT_REQUEST_IN;

--- a/inc/fnmpapi.h
+++ b/inc/fnmpapi.h
@@ -332,18 +332,13 @@ FnMpOidGetRequest(
     _Out_opt_ VOID *InformationBuffer
     )
 {
-    OID_GET_REQUEST_IN In = {0};
-
     //
     // Supports exclusive handles only. Gets the information buffer of an OID
     // request previously pended by the OID filter set via FnMpOidFilter.
     //
-
-    In.Key = Key;
-
     return
         FnIoctl(
-            Handle, FNMP_IOCTL_OID_GET_REQUEST, &In, sizeof(In), InformationBuffer,
+            Handle, FNMP_IOCTL_OID_GET_REQUEST, &Key, sizeof(Key), InformationBuffer,
             *InformationBufferLength, InformationBufferLength, NULL);
 }
 
@@ -370,7 +365,7 @@ FnMpOidCompleteRequest(
     // number of bytes read.
     //
 
-    In.Key = Key;
+    In.Key = &Key;
     In.Status = Status;
     In.InformationBuffer = InformationBuffer;
     In.InformationBufferLength = InformationBufferLength;

--- a/inc/fnmpioctl.h
+++ b/inc/fnmpioctl.h
@@ -7,7 +7,7 @@
 
 EXTERN_C_START
 
-#define FNMP_IOCTL_CURRENT_VERSION 1
+#define FNMP_IOCTL_CURRENT_VERSION 2
 
 #define FNMP_DEVICE_NAME L"\\Device\\FNMP"
 
@@ -80,17 +80,23 @@ typedef struct _MINIPORT_SET_MTU_IN {
 //
 // Parameters for FNMP_IOCTL_OID_GET_REQUEST.
 //
-
-typedef struct _OID_GET_REQUEST_IN {
-    OID_KEY Key;
-} OID_GET_REQUEST_IN;
+// InputBuffer: OID_KEY
+// InputBufferLength: sizeof(OID_KEY)
+//
 
 //
 // Parameters for FNMP_IOCTL_OID_COMPLETE_REQUEST.
 //
 
+typedef struct _OID_COMPLETE_REQUEST_IN_V0 {
+    OID_KEY_V0 Key;
+    NDIS_STATUS Status;
+    UINT32 InformationBufferLength;
+    const VOID *InformationBuffer;
+} OID_COMPLETE_REQUEST_IN_V0;
+
 typedef struct _OID_COMPLETE_REQUEST_IN {
-    OID_KEY Key;
+    const OID_KEY *Key;
     NDIS_STATUS Status;
     UINT32 InformationBufferLength;
     const VOID *InformationBuffer;

--- a/inc/fnoid.h
+++ b/inc/fnoid.h
@@ -22,4 +22,12 @@ EXTERN_C_START
 //
 #define OID_FNMP_SET_NOP                0xff000001
 
+//
+// Method direct no-op.
+//
+// N.B. This MUST be a pre-defined NDIS direct OID, else it will be treated as a
+//      regular OID.
+//
+#define OID_FNMP_METHOD_DIRECT_NOP      OID_TCP_TASK_IPSEC_OFFLOAD_V2_ADD_SA
+
 EXTERN_C_END

--- a/inc/fnoid.h
+++ b/inc/fnoid.h
@@ -17,4 +17,9 @@ EXTERN_C_START
 //
 #define OID_TCP_OFFLOAD_HW_PARAMETERS   0xff000000
 
+//
+// Set no-op.
+//
+#define OID_FNMP_SET_NOP                0xff000001
+
 EXTERN_C_END

--- a/src/common/inc/bounce.h
+++ b/src/common/inc/bounce.h
@@ -33,7 +33,7 @@ NTSTATUS
 BounceBuffer(
     _Inout_ BOUNCE_BUFFER *Bounce,
     _In_ KPROCESSOR_MODE RequestorMode,
-    _In_ CONST VOID *Buffer,
+    _In_opt_ CONST VOID *Buffer,
     _In_ SIZE_T BufferSize,
     _In_ UINT32 Alignment
     );

--- a/src/common/lib/bounce/bounce.c
+++ b/src/common/lib/bounce/bounce.c
@@ -50,7 +50,7 @@ NTSTATUS
 BounceBuffer(
     _Inout_ BOUNCE_BUFFER *Bounce,
     _In_ KPROCESSOR_MODE RequestorMode,
-    _In_ CONST VOID *Buffer,
+    _In_opt_ CONST VOID *Buffer,
     _In_ SIZE_T BufferSize,
     _In_ UINT32 Alignment
     )
@@ -78,8 +78,10 @@ BounceBuffer(
 
     __try {
         if (RequestorMode != KernelMode) {
+            #pragma warning(suppress:6387) // Buffer could be NULL.
             ProbeForRead((VOID *)Buffer, BufferSize, Alignment);
         }
+        #pragma warning(suppress:6387) // Buffer could be NULL.
         RtlCopyVolatileMemory(Bounce->Buffer, Buffer, BufferSize);
     } __except (EXCEPTION_EXECUTE_HANDLER) {
         Status = GetExceptionCode();

--- a/src/lwf/sys/default.c
+++ b/src/lwf/sys/default.c
@@ -43,7 +43,7 @@ DefaultIrpDeviceIoControl(
         break;
 
     case FNLWF_IOCTL_OID_SUBMIT_REQUEST:
-        Status = OidIrpSubmitRequest(Default->Filter, Irp, IrpSp);
+        Status = OidIrpSubmitRequest(Default, Irp, IrpSp);
         break;
 
     case FNLWF_IOCTL_STATUS_SET_FILTER:

--- a/src/lwf/sys/dispatch.c
+++ b/src/lwf/sys/dispatch.c
@@ -92,8 +92,12 @@ LwfIrpCreate(
             EaBuffer->EaValueLength - sizeof(FNLWF_OPEN_PACKET));
 
     if (NT_SUCCESS(Status)) {
-        ASSERT(IrpSp->FileObject->FsContext != NULL);
-        ASSERT(((FILE_OBJECT_HEADER *)IrpSp->FileObject->FsContext)->Dispatch != NULL);
+        FILE_OBJECT_HEADER *FileHeader = IrpSp->FileObject->FsContext;
+
+        ASSERT(FileHeader != NULL);
+        ASSERT(FileHeader->Dispatch != NULL);
+
+        FileHeader->ApiVersion = OpenPacket->ApiVersion;
     }
 
 Exit:

--- a/src/lwf/sys/dispatch.h
+++ b/src/lwf/sys/dispatch.h
@@ -35,4 +35,5 @@ typedef struct FILE_DISPATCH {
 typedef struct FILE_OBJECT_HEADER {
     FNLWF_FILE_TYPE ObjectType;
     const FILE_DISPATCH *Dispatch;
+    UINT32 ApiVersion;
 } FILE_OBJECT_HEADER;

--- a/src/lwf/sys/oid.c
+++ b/src/lwf/sys/oid.c
@@ -315,7 +315,7 @@ OidIrpSubmitRequest(
     BounceInitialize(&InfoBuffer);
     *BytesReturned = 0;
 
-    if (Default->Header.ApiVersion >= 2) {
+    if (Default->Header.ApiVersion >= LWF_APIVER(2)) {
         OID_SUBMIT_REQUEST_IN *In = Irp->AssociatedIrp.SystemBuffer;
 
         if (IrpSp->Parameters.DeviceIoControl.InputBufferLength < sizeof(*In)) {

--- a/src/lwf/sys/oid.h
+++ b/src/lwf/sys/oid.h
@@ -13,7 +13,7 @@ FILTER_DIRECT_OID_REQUEST_COMPLETE FilterDirectOidRequestComplete;
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 OidIrpSubmitRequest(
-    _In_ LWF_FILTER *Filter,
+    _In_ DEFAULT_CONTEXT *Default,
     _In_ IRP *Irp,
     _In_ IO_STACK_LOCATION *IrpSp
     );

--- a/src/lwf/sys/precomp.h
+++ b/src/lwf/sys/precomp.h
@@ -28,3 +28,5 @@
 #include "trace.h"
 #include "tx.h"
 #include "fnlwfioctl.h"
+
+#define LWF_APIVER(_N) (_N)

--- a/src/mp/sys/dispatch.c
+++ b/src/mp/sys/dispatch.c
@@ -99,8 +99,12 @@ MpIrpCreate(
             EaBuffer->EaValueLength - sizeof(FNMP_OPEN_PACKET));
 
     if (NT_SUCCESS(Status)) {
-        ASSERT(IrpSp->FileObject->FsContext != NULL);
-        ASSERT(((FILE_OBJECT_HEADER *)IrpSp->FileObject->FsContext)->Dispatch != NULL);
+        FILE_OBJECT_HEADER *FileHeader = IrpSp->FileObject->FsContext;
+
+        ASSERT(FileHeader != NULL);
+        ASSERT(FileHeader->Dispatch != NULL);
+
+        FileHeader->ApiVersion = OpenPacket->ApiVersion;
     }
 
 Exit:

--- a/src/mp/sys/dispatch.h
+++ b/src/mp/sys/dispatch.h
@@ -33,6 +33,7 @@ typedef struct FILE_DISPATCH {
 typedef struct FILE_OBJECT_HEADER {
     FNMP_FILE_TYPE ObjectType;
     CONST FILE_DISPATCH *Dispatch;
+    UINT32 ApiVersion;
 } FILE_OBJECT_HEADER;
 
 NDIS_STATUS

--- a/src/mp/sys/exclusive.c
+++ b/src/mp/sys/exclusive.c
@@ -32,15 +32,15 @@ ExclusiveIrpDeviceIoControl(
 
     switch (IrpSp->Parameters.DeviceIoControl.IoControlCode) {
     case FNMP_IOCTL_OID_FILTER:
-        Status = MpIrpOidSetFilter(UserContext->Adapter, Irp, IrpSp);
+        Status = MpIrpOidSetFilter(UserContext, Irp, IrpSp);
         break;
 
     case FNMP_IOCTL_OID_GET_REQUEST:
-        Status = MpIrpOidGetRequest(UserContext->Adapter, Irp, IrpSp);
+        Status = MpIrpOidGetRequest(UserContext, Irp, IrpSp);
         break;
 
     case FNMP_IOCTL_OID_COMPLETE_REQUEST:
-        Status = MpIrpOidCompleteRequest(UserContext->Adapter, Irp, IrpSp);
+        Status = MpIrpOidCompleteRequest(UserContext, Irp, IrpSp);
         break;
 
     default:

--- a/src/mp/sys/miniport.h
+++ b/src/mp/sys/miniport.h
@@ -83,7 +83,7 @@ typedef struct _ADAPTER_CONTEXT {
 
     KSPIN_LOCK Lock;
     EX_PUSH_LOCK PushLock;
-    OID_KEY *OidFilterKeys;
+    const OID_KEY *OidFilterKeys;
     UINT32 OidFilterKeyCount;
     LIST_ENTRY FilteredOidRequestLists[OID_REQUEST_INTERFACE_MAX];
     FN_TIMER_HANDLE WatchdogTimer;

--- a/src/mp/sys/oid.c
+++ b/src/mp/sys/oid.c
@@ -571,6 +571,17 @@ MpProcessMethodOid(
         break;
     }
 
+    case OID_FNMP_METHOD_DIRECT_NOP:
+        if (RequestInterface != OID_REQUEST_INTERFACE_DIRECT) {
+            Status = NDIS_STATUS_INVALID_PARAMETER;
+            goto Exit;
+        }
+
+        *BytesRead = InputBufferLength;
+        *BytesWritten = OutputBufferLength;
+        Status = NDIS_STATUS_SUCCESS;
+        break;
+
     default:
         Status = STATUS_NOT_SUPPORTED;
         break;

--- a/src/mp/sys/oid.c
+++ b/src/mp/sys/oid.c
@@ -838,7 +838,7 @@ MpIrpOidSetFilter(
     KIRQL OldIrql = PASSIVE_LEVEL;
     BOOLEAN IsLockHeld = FALSE;
 
-    if (UserContext->Header.ApiVersion >= 2) {
+    if (UserContext->Header.ApiVersion >= MP_APIVER(2)) {
         InKeySize = sizeof(OID_KEY);
     } else {
         InKeySize = sizeof(OID_KEY_V0);
@@ -870,7 +870,7 @@ MpIrpOidSetFilter(
         const VOID *InAnyKey = RTL_PTR_ADD(InKeys, Index * InKeySize);
         OID_KEY *FilterKey = &OidFilterKeys[Index];
 
-        if (UserContext->Header.ApiVersion >= 2) {
+        if (UserContext->Header.ApiVersion >= MP_APIVER(2)) {
             const OID_KEY *InKey = InAnyKey;
             *FilterKey = *InKey;
         } else {
@@ -973,7 +973,7 @@ MpIrpOidGetRequest(
 
     *BytesReturned = 0;
 
-    if (UserContext->Header.ApiVersion >= 2) {
+    if (UserContext->Header.ApiVersion >= MP_APIVER(2)) {
         const OID_KEY *InKey = Irp->AssociatedIrp.SystemBuffer;
         if (IrpSp->Parameters.DeviceIoControl.InputBufferLength < sizeof(*InKey)) {
             Status = STATUS_INVALID_PARAMETER;
@@ -1075,7 +1075,7 @@ MpIrpOidCompleteRequest(
     BounceInitialize(&KeyBuffer);
     BounceInitialize(&InfoBuffer);
 
-    if (UserContext->Header.ApiVersion >= 2) {
+    if (UserContext->Header.ApiVersion >= MP_APIVER(2)) {
         const OID_COMPLETE_REQUEST_IN *InRequest = Irp->AssociatedIrp.SystemBuffer;
 
         if (IrpSp->Parameters.DeviceIoControl.InputBufferLength < sizeof(*InRequest)) {

--- a/src/mp/sys/oid.c
+++ b/src/mp/sys/oid.c
@@ -866,7 +866,8 @@ MpIrpOidSetFilter(
     }
 
     for (UINT32 Index = 0; Index < KeyCount; Index++) {
-        const VOID *InAnyKey = RTL_PTR_ADD(InKeys, (UINT32)(Index * InKeySize));
+        #pragma warning(suppress:26451) // casting 4-byte multiplication to 8-byte type
+        const VOID *InAnyKey = RTL_PTR_ADD(InKeys, Index * InKeySize);
         OID_KEY *FilterKey = &OidFilterKeys[Index];
 
         if (UserContext->Header.ApiVersion >= 2) {

--- a/src/mp/sys/oid.c
+++ b/src/mp/sys/oid.c
@@ -44,6 +44,7 @@ CONST NDIS_OID MpSupportedOidArray[] =
     OID_TCP_OFFLOAD_HW_PARAMETERS,
     OID_QUIC_CONNECTION_ENCRYPTION,
     OID_QUIC_CONNECTION_ENCRYPTION_PROTOTYPE,
+    OID_FNMP_SET_NOP,
 };
 
 CONST UINT32 MpSupportedOidArraySize = sizeof(MpSupportedOidArray);
@@ -504,6 +505,11 @@ MpProcessSetOid(
                     Adapter, &Adapter->OffloadCapabilities, InformationBuffer,
                     InformationBufferLength, NDIS_STATUS_TASK_OFFLOAD_HARDWARE_CAPABILITIES);
 
+            break;
+
+        case OID_FNMP_SET_NOP:
+            *BytesRead = InformationBufferLength;
+            Status = NDIS_STATUS_SUCCESS;
             break;
 
         default:

--- a/src/mp/sys/oid.c
+++ b/src/mp/sys/oid.c
@@ -597,8 +597,8 @@ MiniportRequestHandler(
     NDIS_STATUS Status;
 
     TraceEnter(
-        TRACE_CONTROL, "Adapter=%p Oid=%u RequestType=%u",
-        Adapter, NdisRequest->DATA.Oid, NdisRequest->RequestType);
+        TRACE_CONTROL, "Adapter=%p Oid=%u RequestType=%u PortNumber=%u",
+        Adapter, NdisRequest->DATA.Oid, NdisRequest->RequestType, NdisRequest->PortNumber);
 
     switch (NdisRequest->RequestType)
     {

--- a/src/mp/sys/oid.c
+++ b/src/mp/sys/oid.c
@@ -866,7 +866,7 @@ MpIrpOidSetFilter(
     }
 
     for (UINT32 Index = 0; Index < KeyCount; Index++) {
-        const VOID *InAnyKey = RTL_PTR_ADD(InKeys, Index * InKeySize);
+        const VOID *InAnyKey = RTL_PTR_ADD(InKeys, (UINT32)(Index * InKeySize));
         OID_KEY *FilterKey = &OidFilterKeys[Index];
 
         if (UserContext->Header.ApiVersion >= 2) {

--- a/src/mp/sys/oid.c
+++ b/src/mp/sys/oid.c
@@ -110,10 +110,11 @@ MpFilterOid(
     KeAcquireSpinLock(&Adapter->Lock, &OldIrql);
 
     for (UINT32 Index = 0; Index < Adapter->OidFilterKeyCount; Index++) {
-        OID_KEY *Filter = &Adapter->OidFilterKeys[Index];
+        const OID_KEY *Filter = &Adapter->OidFilterKeys[Index];
         if (NdisRequest->DATA.Oid == Filter->Oid &&
             NdisRequest->RequestType == Filter->RequestType &&
-            RequestInterface == Filter->RequestInterface) {
+            RequestInterface == Filter->RequestInterface &&
+            NdisRequest->PortNumber == Filter->PortNumber) {
             FN_OID_REQUEST_ENTRY *OidEntry;
 
             OidEntry = MpCreateOidRequestEntry(NdisRequest);
@@ -744,6 +745,7 @@ MpOidClearFilter(
     )
 {
     if (Adapter->OidFilterKeys != NULL) {
+        #pragma warning(suppress:4090) // freeing const pointer.
         ExFreePoolWithTag(Adapter->OidFilterKeys, POOLTAG_MP_OID);
         Adapter->OidFilterKeys = NULL;
         Adapter->OidFilterKeyCount = 0;
@@ -822,40 +824,69 @@ MpOidWatchdogIsExpired(
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 MpIrpOidSetFilter(
-    _In_ ADAPTER_CONTEXT *Adapter,
+    _In_ EXCLUSIVE_USER_CONTEXT *UserContext,
     _In_ IRP *Irp,
     _In_ IO_STACK_LOCATION *IrpSp
     )
 {
     NTSTATUS Status;
-    OID_KEY *Keys;
+    ADAPTER_CONTEXT *Adapter = UserContext->Adapter;
+    UINT32 InKeySize;
+    const VOID *InKeys;
+    OID_KEY *OidFilterKeys = NULL;
     UINT32 KeyCount;
     KIRQL OldIrql = PASSIVE_LEVEL;
     BOOLEAN IsLockHeld = FALSE;
 
-    if (IrpSp->Parameters.DeviceIoControl.InputBufferLength < sizeof(*Adapter->OidFilterKeys)) {
+    if (UserContext->Header.ApiVersion >= 2) {
+        InKeySize = sizeof(OID_KEY);
+    } else {
+        InKeySize = sizeof(OID_KEY_V0);
+    }
+
+    if (IrpSp->Parameters.DeviceIoControl.InputBufferLength < InKeySize) {
         Status = STATUS_INVALID_PARAMETER;
         goto Exit;
     }
 
-    if (IrpSp->Parameters.DeviceIoControl.InputBufferLength % sizeof(*Adapter->OidFilterKeys) != 0) {
+    if (IrpSp->Parameters.DeviceIoControl.InputBufferLength % InKeySize != 0) {
         Status = STATUS_INVALID_PARAMETER;
         goto Exit;
     }
 
-    Keys = (OID_KEY *)Irp->AssociatedIrp.SystemBuffer;
-    KeyCount = IrpSp->Parameters.DeviceIoControl.InputBufferLength / sizeof(*Adapter->OidFilterKeys);
+    InKeys = Irp->AssociatedIrp.SystemBuffer;
+    KeyCount = IrpSp->Parameters.DeviceIoControl.InputBufferLength / InKeySize;
+
+    OidFilterKeys =
+        ExAllocatePoolZero(
+            NonPagedPoolNx, KeyCount * sizeof(*Adapter->OidFilterKeys), POOLTAG_MP_OID);
+    if (OidFilterKeys == NULL) {
+        Status = STATUS_NO_MEMORY;
+        goto Exit;
+    }
 
     for (UINT32 Index = 0; Index < KeyCount; Index++) {
-        OID_KEY *Key = &Keys[Index];
-        if (Key->RequestType != NdisRequestQueryInformation &&
-            Key->RequestType != NdisRequestSetInformation &&
-            Key->RequestType != NdisRequestMethod) {
+        const VOID *InAnyKey = RTL_PTR_ADD(InKeys, Index * InKeySize);
+        OID_KEY *FilterKey = &OidFilterKeys[Index];
+
+        if (UserContext->Header.ApiVersion >= 2) {
+            const OID_KEY *InKey = InAnyKey;
+            *FilterKey = *InKey;
+        } else {
+            const OID_KEY_V0 *InKey = InAnyKey;
+            FilterKey->Oid = InKey->Oid;
+            FilterKey->RequestType = InKey->RequestType;
+            FilterKey->RequestInterface = InKey->RequestInterface;
+        }
+
+        if (FilterKey->RequestType != NdisRequestQueryInformation &&
+            FilterKey->RequestType != NdisRequestSetInformation &&
+            FilterKey->RequestType != NdisRequestMethod) {
             Status = STATUS_INVALID_PARAMETER;
             goto Exit;
         }
 
-        if ((UINT32)Key->RequestInterface >= (UINT32)OID_REQUEST_INTERFACE_MAX) {
+        if ((UINT32)FilterKey->RequestInterface >= (UINT32)OID_REQUEST_INTERFACE_MAX) {
             Status = STATUS_INVALID_PARAMETER;
             goto Exit;
         }
@@ -872,14 +903,8 @@ MpIrpOidSetFilter(
         goto Exit;
     }
 
-    Adapter->OidFilterKeys =
-        ExAllocatePoolZero(NonPagedPoolNx, KeyCount * sizeof(*Adapter->OidFilterKeys), POOLTAG_MP_OID);
-    if (Adapter->OidFilterKeys == NULL) {
-        Status = STATUS_NO_MEMORY;
-        goto Exit;
-    }
-
-    RtlCopyMemory(Adapter->OidFilterKeys, Keys, IrpSp->Parameters.DeviceIoControl.InputBufferLength);
+    Adapter->OidFilterKeys = OidFilterKeys;
+    OidFilterKeys = NULL;
     Adapter->OidFilterKeyCount = KeyCount;
     Adapter->UserContext->SetOidFilter = TRUE;
     Status = STATUS_SUCCESS;
@@ -888,6 +913,10 @@ Exit:
 
     if (IsLockHeld) {
         KeReleaseSpinLock(&Adapter->Lock, OldIrql);
+    }
+
+    if (OidFilterKeys != NULL) {
+        ExFreePoolWithTag(OidFilterKeys, POOLTAG_MP_OID);
     }
 
     return Status;
@@ -911,7 +940,9 @@ MpOidFindFilteredOidByKey(
         MpListEntryToOidRequestEntry(Adapter->FilteredOidRequestLists[Key->RequestInterface].Flink);
     Request = RequestEntry->NdisRequest;
 
-    if (Request->DATA.Oid != Key->Oid || Request->RequestType != Key->RequestType) {
+    if (Request->DATA.Oid != Key->Oid ||
+        Request->RequestType != Key->RequestType ||
+        Request->PortNumber != Key->PortNumber) {
         return NULL;
     }
 
@@ -921,15 +952,16 @@ MpOidFindFilteredOidByKey(
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 MpIrpOidGetRequest(
-    _In_ ADAPTER_CONTEXT *Adapter,
+    _In_ EXCLUSIVE_USER_CONTEXT *UserContext,
     _In_ IRP *Irp,
     _In_ IO_STACK_LOCATION *IrpSp
     )
 {
     NTSTATUS Status;
+    ADAPTER_CONTEXT *Adapter = UserContext->Adapter;
     FN_OID_REQUEST_ENTRY *RequestEntry;
     NDIS_OID_REQUEST *Request;
-    OID_GET_REQUEST_IN *In;
+    OID_KEY Key = {0};
     VOID *InformationBuffer;
     UINT32 InformationBufferLength;
     KIRQL OldIrql = PASSIVE_LEVEL;
@@ -940,14 +972,25 @@ MpIrpOidGetRequest(
 
     *BytesReturned = 0;
 
-    if (IrpSp->Parameters.DeviceIoControl.InputBufferLength < sizeof(*In)) {
-        Status = STATUS_INVALID_PARAMETER;
-        goto Exit;
+    if (UserContext->Header.ApiVersion >= 2) {
+        const OID_KEY *InKey = Irp->AssociatedIrp.SystemBuffer;
+        if (IrpSp->Parameters.DeviceIoControl.InputBufferLength < sizeof(*InKey)) {
+            Status = STATUS_INVALID_PARAMETER;
+            goto Exit;
+        }
+        Key = *InKey;
+    } else {
+        const OID_KEY_V0 *InKey = Irp->AssociatedIrp.SystemBuffer;
+        if (IrpSp->Parameters.DeviceIoControl.InputBufferLength < sizeof(*InKey)) {
+            Status = STATUS_INVALID_PARAMETER;
+            goto Exit;
+        }
+        Key.Oid = InKey->Oid;
+        Key.RequestType = InKey->RequestType;
+        Key.RequestInterface = InKey->RequestInterface;
     }
 
-    In = (OID_GET_REQUEST_IN *)Irp->AssociatedIrp.SystemBuffer;
-
-    if ((UINT32)In->Key.RequestInterface >= (UINT32)OID_REQUEST_INTERFACE_MAX) {
+    if ((UINT32)Key.RequestInterface >= (UINT32)OID_REQUEST_INTERFACE_MAX) {
         Status = STATUS_INVALID_PARAMETER;
         goto Exit;
     }
@@ -955,7 +998,7 @@ MpIrpOidGetRequest(
     KeAcquireSpinLock(&Adapter->Lock, &OldIrql);
     IsLockHeld = TRUE;
 
-    RequestEntry = MpOidFindFilteredOidByKey(Adapter, &In->Key);
+    RequestEntry = MpOidFindFilteredOidByKey(Adapter, &Key);
     if (RequestEntry == NULL) {
         Status = STATUS_NOT_FOUND;
         goto Exit;
@@ -1008,15 +1051,18 @@ Exit:
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 MpIrpOidCompleteRequest(
-    _In_ ADAPTER_CONTEXT *Adapter,
+    _In_ EXCLUSIVE_USER_CONTEXT *UserContext,
     _In_ IRP *Irp,
     _In_ IO_STACK_LOCATION *IrpSp
     )
 {
     NTSTATUS Status;
+    ADAPTER_CONTEXT *Adapter = UserContext->Adapter;
     FN_OID_REQUEST_ENTRY *RequestEntry = NULL;
     NDIS_OID_REQUEST *Request = NULL;
-    const OID_COMPLETE_REQUEST_IN *In = NULL;
+    OID_KEY Key = {0};
+    OID_COMPLETE_REQUEST_IN In = {0};
+    BOUNCE_BUFFER KeyBuffer;
     BOUNCE_BUFFER InfoBuffer;
     VOID *InformationBuffer = NULL;
     UINT32 InformationBufferLength = 0;
@@ -1025,29 +1071,59 @@ MpIrpOidCompleteRequest(
     KIRQL OldIrql = PASSIVE_LEVEL;
     BOOLEAN IsLockHeld = FALSE;
 
+    BounceInitialize(&KeyBuffer);
     BounceInitialize(&InfoBuffer);
 
-    if (IrpSp->Parameters.DeviceIoControl.InputBufferLength < sizeof(*In)) {
-        Status = STATUS_INVALID_PARAMETER;
-        goto Exit;
-    }
+    if (UserContext->Header.ApiVersion >= 2) {
+        const OID_COMPLETE_REQUEST_IN *InRequest = Irp->AssociatedIrp.SystemBuffer;
 
-    In = (const OID_COMPLETE_REQUEST_IN *)Irp->AssociatedIrp.SystemBuffer;
+        if (IrpSp->Parameters.DeviceIoControl.InputBufferLength < sizeof(*InRequest)) {
+            Status = STATUS_INVALID_PARAMETER;
+            goto Exit;
+        }
 
-    if ((UINT32)In->Key.RequestInterface >= (UINT32)OID_REQUEST_INTERFACE_MAX) {
-        Status = STATUS_INVALID_PARAMETER;
-        goto Exit;
-    }
+        In = *InRequest;
 
-    if (In->Status == NDIS_STATUS_PENDING && In->InformationBufferLength > 0) {
-        Status = STATUS_INVALID_PARAMETER;
-        goto Exit;
-    }
-
-    if (In->Key.RequestType != NdisRequestSetInformation) {
         Status =
             BounceBuffer(
-                &InfoBuffer, Irp->RequestorMode, In->InformationBuffer, In->InformationBufferLength,
+                &KeyBuffer, Irp->RequestorMode, In.Key, sizeof(OID_KEY), __alignof(OID_KEY));
+        if (!NT_SUCCESS(Status)) {
+            goto Exit;
+        }
+
+        Key = *(const OID_KEY *)KeyBuffer.Buffer;
+    } else {
+        const OID_COMPLETE_REQUEST_IN_V0 *InRequest = Irp->AssociatedIrp.SystemBuffer;
+
+        if (IrpSp->Parameters.DeviceIoControl.InputBufferLength < sizeof(*InRequest)) {
+            Status = STATUS_INVALID_PARAMETER;
+            goto Exit;
+        }
+
+        In.InformationBuffer = InRequest->InformationBuffer;
+        In.InformationBufferLength = InRequest->InformationBufferLength;
+        In.Status = InRequest->Status;
+        Key.Oid = InRequest->Key.Oid;
+        Key.RequestType = InRequest->Key.RequestType;
+        Key.RequestInterface = InRequest->Key.RequestInterface;
+    }
+
+    In.Key = &Key;
+
+    if ((UINT32)In.Key->RequestInterface >= (UINT32)OID_REQUEST_INTERFACE_MAX) {
+        Status = STATUS_INVALID_PARAMETER;
+        goto Exit;
+    }
+
+    if (In.Status == NDIS_STATUS_PENDING && In.InformationBufferLength > 0) {
+        Status = STATUS_INVALID_PARAMETER;
+        goto Exit;
+    }
+
+    if (In.Key->RequestType != NdisRequestSetInformation) {
+        Status =
+            BounceBuffer(
+                &InfoBuffer, Irp->RequestorMode, In.InformationBuffer, In.InformationBufferLength,
                 __alignof(UCHAR));
         if (!NT_SUCCESS(Status)) {
             goto Exit;
@@ -1057,7 +1133,7 @@ MpIrpOidCompleteRequest(
     KeAcquireSpinLock(&Adapter->Lock, &OldIrql);
     IsLockHeld = TRUE;
 
-    RequestEntry = MpOidFindFilteredOidByKey(Adapter, &In->Key);
+    RequestEntry = MpOidFindFilteredOidByKey(Adapter, In.Key);
     if (RequestEntry == NULL) {
         Status = STATUS_NOT_FOUND;
         goto Exit;
@@ -1065,7 +1141,7 @@ MpIrpOidCompleteRequest(
 
     Request = RequestEntry->NdisRequest;
 
-    ASSERT(In->Key.RequestType == Request->RequestType);
+    ASSERT(In.Key->RequestType == Request->RequestType);
 
     if (Request->RequestType == NdisRequestQueryInformation) {
         InformationBuffer = Request->DATA.QUERY_INFORMATION.InformationBuffer;
@@ -1088,7 +1164,7 @@ MpIrpOidCompleteRequest(
         goto Exit;
     }
 
-    if (InformationBufferLength < In->InformationBufferLength) {
+    if (InformationBufferLength < In.InformationBufferLength) {
         Status = STATUS_BUFFER_TOO_SMALL;
         goto Exit;
     }
@@ -1107,24 +1183,25 @@ Exit:
         ASSERT(RequestEntry != NULL);
         ASSERT(Request != NULL);
 
-        if (In->InformationBufferLength > 0) {
-            ASSERT(In->Status != NDIS_STATUS_PENDING);
+        if (In.InformationBufferLength > 0) {
+            ASSERT(In.Status != NDIS_STATUS_PENDING);
 
             if (BytesWritten != NULL) {
-                RtlCopyMemory(InformationBuffer, InfoBuffer.Buffer, In->InformationBufferLength);
-                *BytesWritten = In->InformationBufferLength;
+                RtlCopyMemory(InformationBuffer, InfoBuffer.Buffer, In.InformationBufferLength);
+                *BytesWritten = In.InformationBufferLength;
             }
 
             if (BytesRead != NULL) {
-                *BytesRead = In->InformationBufferLength;
+                *BytesRead = In.InformationBufferLength;
             }
         }
 
-        MpOidCompleteRequest(Adapter, In->Key.RequestInterface, In->Status, Request);
+        MpOidCompleteRequest(Adapter, In.Key->RequestInterface, In.Status, Request);
         MpFreeOidRequestEntry(RequestEntry);
     }
 
     BounceCleanup(&InfoBuffer);
+    BounceCleanup(&KeyBuffer);
 
     return Status;
 }

--- a/src/mp/sys/oid.h
+++ b/src/mp/sys/oid.h
@@ -16,7 +16,7 @@ MINIPORT_CANCEL_DIRECT_OID_REQUEST MiniportCancelDirectRequestHandler;
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 MpIrpOidSetFilter(
-    _In_ ADAPTER_CONTEXT *Adapter,
+    _In_ EXCLUSIVE_USER_CONTEXT *UserContext,
     _In_ IRP *Irp,
     _In_ IO_STACK_LOCATION *IrpSp
     );
@@ -24,7 +24,7 @@ MpIrpOidSetFilter(
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 MpIrpOidGetRequest(
-    _In_ ADAPTER_CONTEXT *Adapter,
+    _In_ EXCLUSIVE_USER_CONTEXT *UserContext,
     _In_ IRP *Irp,
     _In_ IO_STACK_LOCATION *IrpSp
     );
@@ -32,7 +32,7 @@ MpIrpOidGetRequest(
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 MpIrpOidCompleteRequest(
-    _In_ ADAPTER_CONTEXT *Adapter,
+    _In_ EXCLUSIVE_USER_CONTEXT *UserContext,
     _In_ IRP *Irp,
     _In_ IO_STACK_LOCATION *IrpSp
     );

--- a/src/mp/sys/precomp.h
+++ b/src/mp/sys/precomp.h
@@ -31,3 +31,5 @@
 #include "shared.h"
 #include "trace.h"
 #include "tx.h"
+
+#define MP_APIVER(N) (_N)

--- a/src/mp/sys/precomp.h
+++ b/src/mp/sys/precomp.h
@@ -32,4 +32,4 @@
 #include "trace.h"
 #include "tx.h"
 
-#define MP_APIVER(N) (_N)
+#define MP_APIVER(_N) (_N)

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -1617,7 +1617,7 @@ LwfBasicOid()
 
     for (UINT32 Index = 0; Index < RTL_NUMBER_OF(OidKeys); Index++) {
         for (UINT32 Port = 0; Port <= 1; Port++) {
-            const auto &OidKey = OidKeys[Index];
+            OID_KEY OidKey = OidKeys[Index];
             const UINT32 CompletionSize = sizeof(LwfInfoBuffer) / 2;
             auto ExclusiveMp = MpOpenExclusive(FnMpIf->GetIfIndex());
             TEST_NOT_NULL(ExclusiveMp.get());
@@ -1670,7 +1670,7 @@ LwfBasicOid()
             if (OidKey.Oid == OID_GEN_CURRENT_PACKET_FILTER &&
                 OidKey.RequestType == NdisRequestSetInformation) {
                 //
-                // Fix up the current packet filter.
+                // Update our cached packet filter.
                 //
                 OriginalPacketFilter ^= 0x00000001;
             }

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -1643,6 +1643,13 @@ LwfBasicOid()
             TEST_EQUAL(
                 FNMPAPI_STATUS_NOT_FOUND,
                 MpOidGetRequest(ExclusiveMp, OidKey, &MpInfoBufferLength, NULL));
+            if (OidKey.Oid == OID_GEN_CURRENT_PACKET_FILTER &&
+                OidKey.RequestType == NdisRequestSetInformation) {
+                //
+                // Update our cached packet filter.
+                //
+                OriginalPacketFilter ^= 0x00000001;
+            }
 
             LWF_OID_SUBMIT_REQUEST Req;
             Req.Handle = DefaultLwf.get();

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -1628,20 +1628,20 @@ LwfBasicOid()
             LwfInfoBuffer = OriginalPacketFilter ^ (0x00000001);
             LwfInfoBufferLength = sizeof(LwfInfoBuffer);
 
-            //
-            // Verify OIDs are filtered only if port numbers match.
-            //
-            OID_KEY WrongPortKey = OidKeys[Index];
-            WrongPortKey.PortNumber = !WrongPortKey.PortNumber;
-            ULONG WrongInfoBuffer = LwfInfoBuffer;
-            UINT32 WrongInfoBufferLength = LwfInfoBufferLength;
-            TEST_FNLWFAPI(
-                FnLwfOidSubmitRequest(
-                    DefaultLwf.get(), WrongPortKey, &WrongInfoBufferLength, &WrongInfoBuffer));
-            MpInfoBufferLength = 0;
-            TEST_EQUAL(
-                FNMPAPI_STATUS_NOT_FOUND,
-                MpOidGetRequest(ExclusiveMp, OidKeys[Index], &MpInfoBufferLength, NULL));
+            // //
+            // // Verify OIDs are filtered only if port numbers match.
+            // //
+            // OID_KEY WrongPortKey = OidKeys[Index];
+            // WrongPortKey.PortNumber = !WrongPortKey.PortNumber;
+            // ULONG WrongInfoBuffer = LwfInfoBuffer;
+            // UINT32 WrongInfoBufferLength = LwfInfoBufferLength;
+            // TEST_FNLWFAPI(
+            //     FnLwfOidSubmitRequest(
+            //         DefaultLwf.get(), WrongPortKey, &WrongInfoBufferLength, &WrongInfoBuffer));
+            // MpInfoBufferLength = 0;
+            // TEST_EQUAL(
+            //     FNMPAPI_STATUS_NOT_FOUND,
+            //     MpOidGetRequest(ExclusiveMp, OidKeys[Index], &MpInfoBufferLength, NULL));
 
             LWF_OID_SUBMIT_REQUEST Req;
             Req.Handle = DefaultLwf.get();

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -1598,8 +1598,7 @@ LwfBasicOid()
     // Method. (Direct OID)
     //
     InitializeOidKey(
-        &OidKeys[2], OID_QUIC_CONNECTION_ENCRYPTION_PROTOTYPE, NdisRequestMethod,
-        OID_REQUEST_INTERFACE_DIRECT);
+        &OidKeys[2], OID_FNMP_METHOD_DIRECT_NOP, NdisRequestMethod, OID_REQUEST_INTERFACE_DIRECT);
 
     for (UINT32 Index = 0; Index < RTL_NUMBER_OF(OidKeys); Index++) {
         for (UINT32 Port = 0; Port <= 1; Port++) {

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -1632,7 +1632,7 @@ LwfBasicOid()
             //
             // Verify OIDs are filtered only if port numbers match.
             //
-            OID_KEY WrongPortKey = OidKeys[Index];
+            OID_KEY WrongPortKey = OidKey;
             WrongPortKey.PortNumber = !WrongPortKey.PortNumber;
             ULONG WrongInfoBuffer = LwfInfoBuffer;
             UINT32 WrongInfoBufferLength = LwfInfoBufferLength;
@@ -1642,7 +1642,7 @@ LwfBasicOid()
             MpInfoBufferLength = 0;
             TEST_EQUAL(
                 FNMPAPI_STATUS_NOT_FOUND,
-                MpOidGetRequest(ExclusiveMp, OidKeys[Index], &MpInfoBufferLength, NULL));
+                MpOidGetRequest(ExclusiveMp, OidKey, &MpInfoBufferLength, NULL));
 
             LWF_OID_SUBMIT_REQUEST Req;
             Req.Handle = DefaultLwf.get();


### PR DESCRIPTION
OIDs can be sent to specific NDIS ports, which are used, among other things, for setting RSS on a VF via the synthetic virtual NIC above it. Add support for filtering on ports, which was relatively straightforward.

Unfortunately, we failed to make the OID_KEY struct easily extensible: it was encompassed as a field in other structs, so a fair amount of boilerplate had to be rewritten. Future extensions should be as straightforward as originally intended.