### PR TITLE
do not intercept OIDs to non-default port

### DIFF
--- a/src/mp/sys/miniport.c
+++ b/src/mp/sys/miniport.c
@@ -757,7 +757,8 @@ MiniportInitializeHandler(
     RegAttributes->AttributeFlags =
         NDIS_MINIPORT_ATTRIBUTES_NDIS_WDM |
         NDIS_MINIPORT_ATTRIBUTES_SURPRISE_REMOVE_OK |
-        NDIS_MINIPORT_ATTRIBUTES_NO_PAUSE_ON_SUSPEND;
+        NDIS_MINIPORT_ATTRIBUTES_NO_PAUSE_ON_SUSPEND |
+        NDIS_MINIPORT_ATTRIBUTES_NO_OID_INTERCEPT_ON_NONDEFAULT_PORTS;
     RegAttributes->CheckForHangTimeInSeconds = 0;
     RegAttributes->InterfaceType = NdisInterfacePNPBus;
 

--- a/src/mp/sys/oid.c
+++ b/src/mp/sys/oid.c
@@ -39,7 +39,9 @@ CONST NDIS_OID MpSupportedOidArray[] =
     OID_PNP_SET_POWER,
     OID_PNP_QUERY_POWER,
     OID_OFFLOAD_ENCAPSULATION,
+    OID_GEN_RECEIVE_SCALE_CAPABILITIES,
     OID_GEN_RECEIVE_SCALE_PARAMETERS,
+    OID_GEN_DRIVER_VERSION,
     OID_TCP_OFFLOAD_PARAMETERS,
     OID_TCP_OFFLOAD_HW_PARAMETERS,
     OID_QUIC_CONNECTION_ENCRYPTION,
@@ -153,6 +155,7 @@ MpProcessQueryOid(
     PUINT BytesWritten = &NdisRequest->DATA.QUERY_INFORMATION.BytesWritten;
     PUINT BytesNeeded = &NdisRequest->DATA.QUERY_INFORMATION.BytesNeeded;
     BOOLEAN DoCopy = TRUE;
+    UINT16 DriverVersion;
     ULONG LocalData = 0;
     ULONG DataLength = sizeof(LocalData);
     VOID *Data = &LocalData;
@@ -220,6 +223,13 @@ MpProcessQueryOid(
         case OID_GEN_TRANSMIT_BLOCK_SIZE:
         case OID_GEN_RECEIVE_BLOCK_SIZE:
             LocalData = Adapter->MtuSize + ETH_HDR_LEN;
+            break;
+
+        case OID_GEN_DRIVER_VERSION:
+            DriverVersion =
+                (NDIS_MINIPORT_MAJOR_VERSION << RTL_BITS_OF(UINT8)) | NDIS_MINIPORT_MINOR_VERSION;
+            DataLength = sizeof(DriverVersion);
+            Data = &DriverVersion;
             break;
 
         case OID_GEN_VENDOR_ID:

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -1568,7 +1568,7 @@ MpVerifyPortState(
         LwfOidAllocateAndSubmitRequest<NDIS_PORT_ARRAY>(LwfHandle, OidKey, &BytesReturned);
     TEST_NOT_NULL(PortArray.get());
 
-    for (UINT32 i = 0; i < PortArray->NumberOfPorts; i++) {
+    for (UINT64 i = 0; i < PortArray->NumberOfPorts; i++) {
         const NDIS_PORT_CHARACTERISTICS *PortCharacteristics = (const NDIS_PORT_CHARACTERISTICS *)
             RTL_PTR_ADD(PortArray.get(), PortArray->OffsetFirstPort + PortArray->ElementSize * i);
 


### PR DESCRIPTION
NDIS intercepts OIDs to non-default ports by default, which breaks our use case for port-specific OID handling.

Also stub support for RSS-related OIDs that are typically handled by NDIS.