### PR TITLE
include all architectures in dev nuget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,39 @@ jobs:
         name: logs_func_${{ matrix.apimode }}_${{ matrix.os }}_${{ matrix.configuration }}_${{ matrix.platform }}
         path: artifacts/logs
 
-  create_artifacts:
-    name: Create Release Artifacts
+  create_dev_artifacts:
+    name: Create Dev Artifacts
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [Release]
+    runs-on: windows-2022
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+    - name: Download x64 Artifacts
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+      with:
+        name: bin_${{ matrix.configuration }}_x64
+        path: artifacts/bin
+    - name: Download arm64 Artifacts
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+      with:
+        name: bin_${{ matrix.configuration }}_arm64
+        path: artifacts/bin
+    - name: Create Nuget Package
+      shell: PowerShell
+      run: tools/create-nuget-package.ps1 -Config ${{ matrix.configuration }} -Platform x64, arm64
+    - name: Upload Release Artifacts
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+      with:
+        name: release_dev_artifacts_${{ matrix.configuration }}
+        path: |
+          artifacts/pkg/**/*.nupkg
+
+  create_runtime_artifacts:
+    name: Create Runtime Artifacts
     needs: build
     strategy:
       fail-fast: false
@@ -129,22 +160,15 @@ jobs:
       with:
         name: bin_${{ matrix.configuration }}_${{ matrix.platform }}
         path: artifacts/bin
-    - name: Create Nuget Package
-      shell: PowerShell
-      run: tools/create-nuget-package.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
-    - name: Create Dev Kit
-      shell: PowerShell
-      run: tools/create-devkit.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
     - name: Create Runtime Kit
       shell: PowerShell
       run: tools/create-runtimekit.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
     - name: Upload Release Artifacts
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       with:
-        name: release_artifacts_${{ matrix.configuration }}_${{ matrix.platform }}
+        name: release_runtime_artifacts_${{ matrix.configuration }}_${{ matrix.platform }}
         path: |
           artifacts/kit/**/*.zip
-          artifacts/pkg/**/*.nupkg
 
   Complete:
     name: Complete

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
   Complete:
     name: Complete
     if: always()
-    needs: [build, functional_tests, create_artifacts]
+    needs: [build, functional_tests, create_dev_artifacts, create_runtime_artifacts]
     runs-on: ubuntu-latest
     permissions: {} # No need for any permissions.
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
     - name: Upload Release Artifacts
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       with:
-        name: release_dev_artifacts_${{ matrix.configuration }}
+        name: release_artifacts_${{ matrix.configuration }}
         path: |
           artifacts/pkg/**/*.nupkg
 
@@ -166,7 +166,7 @@ jobs:
     - name: Upload Release Artifacts
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       with:
-        name: release_runtime_artifacts_${{ matrix.configuration }}_${{ matrix.platform }}
+        name: release_artifacts_${{ matrix.configuration }}
         path: |
           artifacts/kit/**/*.zip
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
     - name: Upload Release Artifacts
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       with:
-        name: release_artifacts_${{ matrix.configuration }}
+        name: release_dev_artifacts_${{ matrix.configuration }}
         path: |
           artifacts/pkg/**/*.nupkg
 
@@ -166,7 +166,7 @@ jobs:
     - name: Upload Release Artifacts
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       with:
-        name: release_artifacts_${{ matrix.configuration }}
+        name: release_runtime_artifacts_${{ matrix.configuration }}_${{ matrix.platform }}
         path: |
           artifacts/kit/**/*.zip
 

--- a/tools/nuget/win-net-test.nuspec.in
+++ b/tools/nuget/win-net-test.nuspec.in
@@ -17,8 +17,8 @@
 	<files>
 		<file src="..\..\..\tools\nuget\README.md" target="."/>
 		<file src="..\..\..\tools\nuget\win-net-test.props" target="build\native"/>
-		<file src="..\..\..\artifacts\bin\{archconfig}\fnsock_um.lib" target="build\native\lib"/>
-		<file src="..\..\..\artifacts\bin\{archconfig}\fnsock_km.lib" target="build\native\lib"/>
+		<file src="..\..\..\artifacts\bin\{arch}_{config}\fnsock_um.lib" target="build\native\lib\{arch}"/>
+		<file src="..\..\..\artifacts\bin\{arch}_{config}\fnsock_km.lib" target="build\native\lib\{arch}"/>
 		<file src="..\..\..\inc\*" target="build\native\include" />
 	</files>
 </package>

--- a/tools/nuget/win-net-test.props
+++ b/tools/nuget/win-net-test.props
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0">
   <PropertyGroup>
-    <WntLibPath>$(MSBuildThisFileDirectory)lib</WntLibPath>
-    <WntBinPath>$(MSBuildThisFileDirectory)bin</WntBinPath>
+    <WntLibPath>$(MSBuildThisFileDirectory)lib\$(Platform)</WntLibPath>
+    <WntBinPath>$(MSBuildThisFileDirectory)bin\$(Platform)</WntBinPath>
     <WntIncPath>$(MSBuildThisFileDirectory)include</WntIncPath>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major": 1, "minor": 1, "patch": 0 }
+{ "major": 1, "minor": 2, "patch": 0 }


### PR DESCRIPTION
The common practice, and most convenient design, for developer nugets include all architectures.