### PR TITLE
get newest wdk working

### DIFF
--- a/src/common/inc/fnrtl.h
+++ b/src/common/inc/fnrtl.h
@@ -173,6 +173,8 @@ RtlReleasePushLockShared(
     KeLeaveCriticalRegion();
 }
 
+#ifndef _RTL_VOL_MEM_ACCESSORS_
+
 FORCEINLINE
 VOID
 RtlCopyVolatileMemory(
@@ -184,6 +186,8 @@ RtlCopyVolatileMemory(
     RtlCopyMemory(Destination, (const VOID *)Source, Size);
     _ReadWriteBarrier();
 }
+
+#endif
 
 FORCEINLINE
 HANDLE

--- a/src/common/lib/bounce/bounce.vcxproj
+++ b/src/common/lib/bounce/bounce.vcxproj
@@ -21,12 +21,6 @@
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
     </ClCompile>
-    <Link>
-      <AdditionalDependencies>
-        volatileaccessk.lib;
-        %(AdditionalDependencies)
-      </AdditionalDependencies>
-    </Link>
   </ItemDefinitionGroup>
   <Import Project="$(UndockedDir)vs\windows.undocked.targets" />
 </Project>

--- a/src/common/lib/bounce/bounce.vcxproj
+++ b/src/common/lib/bounce/bounce.vcxproj
@@ -21,6 +21,12 @@
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
     </ClCompile>
+    <Link>
+      <AdditionalDependencies>
+        volatileaccessk.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
+    </Link>
   </ItemDefinitionGroup>
   <Import Project="$(UndockedDir)vs\windows.undocked.targets" />
 </Project>

--- a/src/lwf/sys/fnlwf.vcxproj
+++ b/src/lwf/sys/fnlwf.vcxproj
@@ -57,6 +57,9 @@
       <AdditionalDependencies>
         ndis.lib;
         netio.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(LatestWdkPlatformVersion)' &gt;= '10.0.26100.0'">
         volatileaccessk.lib;
         %(AdditionalDependencies)
       </AdditionalDependencies>

--- a/src/lwf/sys/fnlwf.vcxproj
+++ b/src/lwf/sys/fnlwf.vcxproj
@@ -57,6 +57,7 @@
       <AdditionalDependencies>
         ndis.lib;
         netio.lib;
+        volatileaccessk.lib;
         %(AdditionalDependencies)
       </AdditionalDependencies>
     </Link>

--- a/src/mp/sys/fnmp.vcxproj
+++ b/src/mp/sys/fnmp.vcxproj
@@ -59,6 +59,7 @@
       <AdditionalDependencies>
         ndis.lib;
         netio.lib;
+        volatileaccessk.lib;
         %(AdditionalDependencies)
       </AdditionalDependencies>
     </Link>

--- a/src/mp/sys/fnmp.vcxproj
+++ b/src/mp/sys/fnmp.vcxproj
@@ -59,6 +59,9 @@
       <AdditionalDependencies>
         ndis.lib;
         netio.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(LatestWdkPlatformVersion)' &gt;= '10.0.26100.0'">
         volatileaccessk.lib;
         %(AdditionalDependencies)
       </AdditionalDependencies>


### PR DESCRIPTION
The `RtlCopyVolatileMemory` is defined in the newest WDK, which GitHub implicitly started using.