### PR TITLE
Build using latest WDK and SDK via nuget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Some driver developers are building for WS2022 LTSC targets using VS2019 +
-        # the Windows Server 2022 WDK, so validate our project still builds in that
-        # environment, in addition to the default WS 2022.
-        os: [2019, 2022]
+        os: [2022]
         configuration: [Release, Debug]
         platform: [x64, arm64]
-        exclude:
-        - os: 2019
-          platform: arm64
     runs-on: windows-${{ matrix.os }}
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
         submodules: recursive
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
+      with:
+        msbuild-architecture: x64
     - name: Prepare Machine
       shell: PowerShell
       run: tools/prepare-machine.ps1 -ForBuild -Verbose

--- a/src/common/lib/bounce/bounce.vcxproj
+++ b/src/common/lib/bounce/bounce.vcxproj
@@ -8,8 +8,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
-  <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.kernel.props" />
   <ItemGroup>
     <ClCompile Include="bounce.c" />

--- a/src/common/lib/fnio/fnio.vcxproj
+++ b/src/common/lib/fnio/fnio.vcxproj
@@ -8,8 +8,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
-  <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.kernel.props" />
   <ItemGroup>
     <ClCompile Include="enqueue.c" />

--- a/src/isr/svc/isrsvc.vcxproj
+++ b/src/isr/svc/isrsvc.vcxproj
@@ -8,7 +8,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/src/isr/sys/isrdrv.vcxproj
+++ b/src/isr/sys/isrdrv.vcxproj
@@ -8,8 +8,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
-  <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.kernel.props" />
   <ItemGroup>
     <ClCompile Include="client.c" />

--- a/src/lwf/sys/fnlwf.vcxproj
+++ b/src/lwf/sys/fnlwf.vcxproj
@@ -8,8 +8,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
-  <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.kernel.props" />
   <ItemGroup>
     <ProjectReference Include="$(SolutionDir)src\common\lib\bounce\bounce.vcxproj">

--- a/src/lwf/sys/inf/fnlwf.inx
+++ b/src/lwf/sys/inf/fnlwf.inx
@@ -18,9 +18,9 @@ fnlwf.CopyFiles = %DIRID_DRIVERS%
 fnlwf.sys = 1
 
 [Manufacturer]
-%Msft% = MSFT,NT$ARCH$
+%Msft% = MSFT,NT$ARCH$.10.0...17763
 
-[MSFT.NT$ARCH$]
+[MSFT.NT$ARCH$.10.0...17763]
 %fnlwf.DeviceDesc% = Install, ms_fnlwf
 
 [Install]

--- a/src/mp/sys/fnmp.vcxproj
+++ b/src/mp/sys/fnmp.vcxproj
@@ -8,8 +8,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
-  <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.kernel.props" />
   <ItemGroup>
     <ProjectReference Include="$(SolutionDir)src\common\lib\bounce\bounce.vcxproj">

--- a/src/mp/sys/inf/fnmp.inx
+++ b/src/mp/sys/inf/fnmp.inx
@@ -10,8 +10,8 @@
  PnpLockdown = 1
 
 [Manufacturer]
-%Msft%=Microsoft, NT$ARCH$
-[Microsoft.NT$ARCH$]
+%Msft% = MSFT,NT$ARCH$.10.0...17763
+[MSFT.NT$ARCH$.10.0...17763]
 %fnmp.DeviceDesc% = fnmp.ndi, ms_fnmp
 
 [fnmp.ndi.NT]

--- a/src/mp/sys/packages.config
+++ b/src/mp/sys/packages.config
@@ -4,4 +4,9 @@
   <package id="Microsoft.SourceLink.AzureRepos.Git" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />
+  <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.ARM64" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.2454" targetFramework="native" />
 </packages>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/src/sock/km/fnsock_km.vcxproj
+++ b/src/sock/km/fnsock_km.vcxproj
@@ -8,8 +8,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
-  <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.kernel.props" />
   <ItemGroup>
     <ProjectReference Include="$(SolutionDir)src\wskclient\wskclient.vcxproj">

--- a/src/sock/um/fnsock_um.vcxproj
+++ b/src/sock/um/fnsock_um.vcxproj
@@ -8,7 +8,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <ItemGroup>
     <ClCompile Include="sock.c" />

--- a/src/wnt.cpp.kernel.props
+++ b/src/wnt.cpp.kernel.props
@@ -1,6 +1,7 @@
 <!-- Kernel mode specific properties -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Project-wide compile properties (e.g. defines, includes) -->
+  <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>
@@ -20,5 +21,6 @@
   </ItemDefinitionGroup>
   <PropertyGroup>
     <EnableInf2cat>true</EnableInf2cat>
+    <InfVerif_AdditionalOptions>/rulever 10.0.17763 $(InfVerif_AdditionalOptions)</InfVerif_AdditionalOptions>
   </PropertyGroup>
 </Project>

--- a/src/wnt.cpp.props
+++ b/src/wnt.cpp.props
@@ -1,4 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WDKVersion>10.0.26100.2454</WDKVersion>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -7,4 +10,20 @@
       <DisableSpecificWarnings>26812;5252;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.WDK.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.WDK.$(Platform).props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.WDK.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.WDK.$(Platform).props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.$(Platform).props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.$(Platform).props')" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.targets')" />
+  </ImportGroup>
+  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.$(Platform).props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.$(Platform).props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.WDK.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.WDK.$(Platform).props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.WDK.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.WDK.$(Platform).props'))" />
+  </Target>
 </Project>

--- a/src/wskclient/wskclient.vcxproj
+++ b/src/wskclient/wskclient.vcxproj
@@ -8,8 +8,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
-  <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.kernel.props" />
   <ItemGroup>
     <ClCompile Include="wskclient.c" />

--- a/test/cxplat/lib/km/cxplat_km.vcxproj
+++ b/test/cxplat/lib/km/cxplat_km.vcxproj
@@ -8,8 +8,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
-  <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.kernel.props" />
   <ItemGroup>
     <ClCompile Include="cxplat.cpp" />

--- a/test/cxplat/lib/um/cxplat_um.vcxproj
+++ b/test/cxplat/lib/um/cxplat_um.vcxproj
@@ -8,7 +8,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <ItemGroup>
     <ClCompile Include="cxplat.cpp" />

--- a/test/functional/bin/fnfunctionaltests.vcxproj
+++ b/test/functional/bin/fnfunctionaltests.vcxproj
@@ -10,7 +10,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <ItemGroup>
     <ProjectReference Include="$(SolutionDir)test\functional\bin\km\fnfunctionaltestdrv.vcxproj">

--- a/test/functional/bin/km/fnfunctionaltestdrv.vcxproj
+++ b/test/functional/bin/km/fnfunctionaltestdrv.vcxproj
@@ -8,8 +8,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
-  <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.kernel.props" />
   <ItemGroup>
     <ProjectReference Include="$(SolutionDir)test\functional\lib\fnfunctionaltestlib_km.vcxproj">

--- a/test/functional/lib/fnfunctionaltestlib_km.vcxproj
+++ b/test/functional/lib/fnfunctionaltestlib_km.vcxproj
@@ -8,8 +8,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
-  <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.kernel.props" />
   <ItemGroup>
     <ClCompile Include="tests.cpp" />

--- a/test/functional/lib/fnfunctionaltestlib_um.vcxproj
+++ b/test/functional/lib/fnfunctionaltestlib_um.vcxproj
@@ -8,7 +8,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <ItemGroup>
     <ClCompile Include="tests.cpp" />

--- a/test/pkthlp/km/pkthlp_km.vcxproj
+++ b/test/pkthlp/km/pkthlp_km.vcxproj
@@ -8,7 +8,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <ItemGroup>
     <ClCompile Include="..\pkthlp.c" />

--- a/test/pkthlp/um/pkthlp_um.vcxproj
+++ b/test/pkthlp/um/pkthlp_um.vcxproj
@@ -8,7 +8,6 @@
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>
     <UndockedSourceLink>true</UndockedSourceLink>
   </PropertyGroup>
-  <Import Project="$(UndockedDir)vs\windows.undocked.props" />
   <Import Project="$(SolutionDir)src\wnt.cpp.props" />
   <ItemGroup>
     <ClCompile Include="..\pkthlp.c" />

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -52,11 +52,18 @@ if (!$?) {
     Write-Error "Restoring NuGet packages failed: $LastExitCode"
 }
 
+# Unfortunately, global state cached by MsBuild.exe combined with WDK bugs
+# causes unreliable builds. Specifically, the Telemetry task implemented by
+# WDK's Microsoft.DriverKit.Build.Tasks.17.0.dll has breaking API changes
+# that are not invalidated by loading different WDKs. Therefore we disable
+# MsBuild.exe reuse with /nodeReuse:false.
+
 msbuild.exe $RootDir\wnt.sln `
     /p:Configuration=$Config `
     /p:Platform=$Platform `
     /p:SignMode=TestSign `
     /t:$($Tasks -join ",") `
+    /nodeReuse:false `
     /maxCpuCount
 if (!$?) {
     Write-Error "Build failed: $LastExitCode"


### PR DESCRIPTION
Instead of relying on the WDK and SDK provided by the build machines, take a specific dependency using nuget packages. 

Fix a few build breaks caused by the new WDK.

Also remove building on WS2019, which is causing headaches and is obsolete as a build env. WS2019 is still used for testing.