### PR TITLE
Delete nuget.config

### DIFF
--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
This file should not be necessary. In our OneBranch build pipeline, the ES automatically supplies it.