### PR TITLE
Fix comparison when wdk version is not set

### DIFF
--- a/src/lwf/sys/fnlwf.vcxproj
+++ b/src/lwf/sys/fnlwf.vcxproj
@@ -57,7 +57,7 @@
         netio.lib;
         %(AdditionalDependencies)
       </AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(LatestWdkPlatformVersion)' &gt;= '10.0.26100.0'">
+      <AdditionalDependencies Condition="'$(LatestWdkPlatformVersion)' != '' And '$(LatestWdkPlatformVersion)' &gt;= '10.0.26100.0'">
         volatileaccessk.lib;
         %(AdditionalDependencies)
       </AdditionalDependencies>

--- a/src/mp/sys/fnmp.vcxproj
+++ b/src/mp/sys/fnmp.vcxproj
@@ -59,7 +59,7 @@
         netio.lib;
         %(AdditionalDependencies)
       </AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(LatestWdkPlatformVersion)' &gt;= '10.0.26100.0'">
+      <AdditionalDependencies Condition="'$(LatestWdkPlatformVersion)' != '' And '$(LatestWdkPlatformVersion)' &gt;= '10.0.26100.0'">
         volatileaccessk.lib;
         %(AdditionalDependencies)
       </AdditionalDependencies>


### PR DESCRIPTION
Allow nuget to parse the vcxproj files before the LatestWdkPlatformVersion variable is set, which is needed to initially restore nuget packages.

Without this, the parsing fails, trying to compare a numerical value with an empty string.