### PR TITLE
Add helpers to build an ICMP echo reply frame

### DIFF
--- a/inc/pkthlp.h
+++ b/inc/pkthlp.h
@@ -332,6 +332,7 @@ PktBuildIcmp4Frame(
         return FALSE;
     }
     void *PktBuffer = Buffer;
+    RtlZeroMemory(PktBuffer, TotalLength);
 
     // Fill Ethernet headers.
     ETHERNET_HEADER *EthernetHeader = (ETHERNET_HEADER *) PktBuffer;
@@ -383,8 +384,8 @@ PktBuildIcmp6Frame(
     if (*BufferSize < TotalLength) {
         return FALSE;
     }
-
     void* PktBuffer = Buffer;
+    RtlZeroMemory(PktBuffer, TotalLength);
 
     // Fill Ethernet headers.
     ETHERNET_HEADER *EthernetHeader = (ETHERNET_HEADER *) PktBuffer;
@@ -423,12 +424,11 @@ PktBuildIcmp6Frame(
 
     UINT16 UpperLayerPacketLen = sizeof(ICMPV6_HEADER) + PayloadLength;
 
-    UINT32 UpperLayerPacketLen2 = htons(UpperLayerPacketLen);
-    Checksum += PktPartialChecksum(&UpperLayerPacketLen2, sizeof(UINT32));
+    UpperLayerPacketLen = htons(UpperLayerPacketLen);
+    Checksum += PktPartialChecksum(&UpperLayerPacketLen, sizeof(UpperLayerPacketLen));
     Checksum += (IpHeader->NextHeader << 8);
 
     // ICMPv6 header
-    Icmp6Hdr->Checksum = 0;
     Checksum += PktPartialChecksum(Icmp6Hdr, sizeof(*Icmp6Hdr));
 
     // Payload


### PR DESCRIPTION
A use-case in XDP was missing this capability. 

I implemented that helper in the XDP codebase, but let's move it to this repo.

TESTING:

See: 

https://github.com/microsoft/xdp-for-windows/actions/runs/18952170141/job/54119842031?pr=912, from the XDP PR, which contains the helpers implemented in this PR. 

Passed GenericRxMatchIcmpEchoReplyV4 [1 s]
Passed GenericRxMatchIcmpEchoReplyV6 [1 s]