### PR TITLE
Add compile-time knob to skip kernel defines/includes

### DIFF
--- a/inc/fnioctl_um.h
+++ b/inc/fnioctl_um.h
@@ -5,12 +5,12 @@
 
 #pragma once
 
+#ifndef FN_SKIP_WINCOMMON
 #include <windows.h>
 #include <winioctl.h>
-#ifndef FN_SKIP_KERNEL_DEFINES
 #include <winternl.h>
-#endif
 #include <ifdef.h>
+#endif
 
 EXTERN_C_START
 
@@ -26,7 +26,7 @@ EXTERN_C_START
 // This file implements common file handle and IOCTL helpers.
 //
 
-#ifndef FN_SKIP_KERNEL_DEFINES
+#ifndef FN_SKIP_WINCOMMON
 //
 // This struct is defined in public kernel headers, but not user mode headers.
 //

--- a/inc/fnioctl_um.h
+++ b/inc/fnioctl_um.h
@@ -7,7 +7,9 @@
 
 #include <windows.h>
 #include <winioctl.h>
+#ifndef FN_SKIP_KERNEL_DEFINES
 #include <winternl.h>
+#endif
 #include <ifdef.h>
 
 EXTERN_C_START
@@ -24,6 +26,7 @@ EXTERN_C_START
 // This file implements common file handle and IOCTL helpers.
 //
 
+#ifndef FN_SKIP_KERNEL_DEFINES
 //
 // This struct is defined in public kernel headers, but not user mode headers.
 //
@@ -34,6 +37,7 @@ typedef struct _FILE_FULL_EA_INFORMATION {
     USHORT EaValueLength;
     CHAR EaName[1];
 } FILE_FULL_EA_INFORMATION;
+#endif
 
 typedef HANDLE FNIOCTL_HANDLE;
 

--- a/inc/fniotypes.h
+++ b/inc/fniotypes.h
@@ -16,10 +16,12 @@
 // However, it is most likely too late to include these headers by the time this
 // header is included.
 //
+#ifndef FN_SKIP_WINCOMMON
 #include <windows.h>
 #include <winsock2.h>
 #include <ws2ipdef.h>
 #include <iphlpapi.h>
+#endif
 #include <ndisoobtypes.h>
 #endif
 


### PR DESCRIPTION
Provide a way to avoid duplicate definitions if consumer already includes these definitions in another way