### PR TITLE
add missing inline decorators

### DIFF
--- a/inc/fnlwfapi.h
+++ b/inc/fnlwfapi.h
@@ -53,6 +53,7 @@ FnLwfUnloadApi(
     }
 }
 
+FNLWFAPI
 VOID *
 FnLwfInitializeEa(
     _In_ FNLWF_FILE_TYPE FileType,

--- a/inc/fnmpapi.h
+++ b/inc/fnmpapi.h
@@ -68,6 +68,7 @@ FnMpUnloadApi(
     }
 }
 
+FNMPAPI
 VOID *
 FnMpInitializeEa(
     _In_ FNMP_FILE_TYPE FileType,


### PR DESCRIPTION
 A couple header inline routines are missing the `inline` keyword, causing linker fails if the function gets used in multiple .c files.